### PR TITLE
wildpush: Allowing for pushes from arbitrary paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Use `drive help` for further reference.
 	$ drive pull [-r -no-prompt path] # pulls from remote
 	$ drive push [-r -no-prompt path] # pushes to the remote
 	$ drive push [-r -hidden path] # pushes also hidden directories and paths to the remote
+	# To push from a location not on the drive:
+	$ drive push -m $LOCATION .
 	$ drive diff [path] # outputs a diff of local and remote
 	$ drive publish [path] # publishes a file, outputs URL
 

--- a/commands.go
+++ b/commands.go
@@ -33,6 +33,12 @@ type Options struct {
 	IsForce     bool
 	// Hidden discovers hidden paths if set
 	Hidden bool
+	// Mounts is a list of all mountpoints
+	// of paths that are not in the current drive context
+	Mounts []*config.MountPoint
+	// Sources is a of list all paths that are
+	// within the scope/path of the current gd context
+	Sources []string
 }
 
 type Commands struct {

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 )
 
 type Context struct {
@@ -27,6 +29,24 @@ type Context struct {
 	ClientSecret string `json:"client_secret"`
 	RefreshToken string `json:"refresh_token"`
 	AbsPath      string `json:"-"`
+}
+
+type MountPoint struct {
+	Name      string
+	AbsPath   string
+	MountPath string
+}
+
+func (mpt *MountPoint) mounted() bool {
+	// TODO: Find proper scheme for resolving symlinks
+	return true
+}
+
+func (mpt *MountPoint) Unmount() error {
+	if mpt.mounted() {
+		return os.RemoveAll(mpt.MountPath)
+	}
+	return nil
 }
 
 func (c *Context) AbsPathOf(fileOrDirPath string) string {
@@ -92,4 +112,39 @@ func gdPath(absPath string) string {
 
 func credentialsPath(absPath string) string {
 	return path.Join(gdPath(absPath), "credentials.json")
+}
+
+func MountPoints(contextPath, contextAbsPath string, paths []string, hidden bool) (
+	mtPoints []*MountPoint, sources []string) {
+	visitors := map[string]bool{}
+
+	for _, path := range paths {
+		_, visited := visitors[path]
+		if visited {
+			continue
+		}
+		visitors[path] = true
+
+		localinfo, err := os.Stat(path)
+		if err != nil || localinfo == nil {
+			continue
+		}
+
+		base := filepath.Base(path)
+		if !hidden && strings.HasPrefix(base, ".") {
+			continue
+		}
+		mountPath := filepath.Join(contextAbsPath, base)
+		err = os.Symlink(path, mountPath)
+		if err != nil { // Most definitely exists within the drive
+			sources = append(sources, strings.Join([]string{"", path}, "/"))
+			continue
+		}
+		mtPoints = append(mtPoints, &MountPoint{
+			AbsPath:   path,
+			MountPath: mountPath,
+			Name:      strings.Join([]string{"", contextPath, base}, "/"),
+		})
+	}
+	return
 }


### PR DESCRIPTION
This enables pushes from arbitrary paths e.g
`drive push -r /Volumes/SDCard ~/gdrive`
instead of always having to copy content first into the drive
then pushing it.
Basic idea is the creation of a symlink that gets cleared
on deferal.
