### PR TITLE
no-clobber: implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Use `drive help` for further reference.
 	$ drive pull [-r -no-prompt path] # pulls from remote
 	$ drive pull [-r -no-prompt -export ext1,ext2,ext3 path] # pulls from remote and exports Docs + Sheets to one of its export formats.
     e.g:
-	$ drive pull [-r -no-prompt -export pdf,docx,rtf,html ReportII.txt] # pull ReportII.txt from remote and 
-        export it to pdf, docx, rtf and html
+	$ drive pull [-r -no-prompt -export pdf,docx,rtf,html ReportII.txt] # pull ReportII.txt from
+	 remote and export it to pdf, docx, rtf and html.
         
 	$ drive push [-r -no-prompt path] # pushes to the remote
 	$ drive push [-r -hidden path] # pushes also hidden directories and paths to the remote
@@ -26,6 +26,11 @@ Use `drive help` for further reference.
 	$ drive diff [path] # outputs a diff of local and remote
 	$ drive pub [path] # publishes a file, outputs URL
 	$ drive unpub [path] # revokes public access to the file
+
+	# Note using the no-clobber option for push or pull ensures that only ADDITIONS are made
+	# any modifications or deletions are ignored and those files are safe.
+	$ drive pull -no-clobber
+	$ drive push -no-clobber
 
 ## Configuration
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -62,9 +62,11 @@ type pullCmd struct {
 	export      *string
 	isRecursive *bool
 	isNoPrompt  *bool
+	noClobber   *bool
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.noClobber = fs.Bool("no-clobber", false, "prevents overwriting of old content")
 	cmd.export = fs.String(
 		"export", "", "comma separated list of formats to export your docs + sheets files")
 	cmd.isRecursive = fs.Bool("r", true, "performs the pull action recursively")
@@ -88,14 +90,16 @@ func (cmd *pullCmd) Run(args []string) {
 	exports := nonEmptyStrings(strings.Split(*cmd.export, ","))
 
 	exitWithError(drive.New(context, &drive.Options{
-		Path:        path,
 		Exports:     exports,
 		IsNoPrompt:  *cmd.isNoPrompt,
 		IsRecursive: *cmd.isRecursive,
+		NoClobber:   *cmd.noClobber,
+		Path:        path,
 	}).Pull())
 }
 
 type pushCmd struct {
+	noClobber   *bool
 	hidden      *bool
 	isNoPrompt  *bool
 	isRecursive *bool
@@ -103,6 +107,7 @@ type pushCmd struct {
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.noClobber = fs.Bool("no-clobber", false, "allows overwriting of old content")
 	cmd.hidden = fs.Bool("hidden", false, "allows syncing of hidden paths")
 	cmd.isRecursive = fs.Bool("r", true, "performs the push action recursively")
 	cmd.isNoPrompt = fs.Bool("no-prompt", false, "shows no prompt before applying the push action")
@@ -116,10 +121,11 @@ func (cmd *pushCmd) Run(args []string) {
 	} else {
 		context, path := discoverContext(args)
 		exitWithError(drive.New(context, &drive.Options{
-			Path:        path,
+			NoClobber:   *cmd.noClobber,
 			Hidden:      *cmd.hidden,
 			IsNoPrompt:  *cmd.isNoPrompt,
 			IsRecursive: *cmd.isRecursive,
+			Path:        path,
 		}).Push())
 	}
 }
@@ -154,11 +160,12 @@ func pushMounted(cmd *pushCmd, args []string) {
 	sources = append(sources, auxSrcs...)
 
 	exitWithError(drive.New(context, &drive.Options{
-		Path:        path,
 		Hidden:      *cmd.hidden,
 		IsNoPrompt:  *cmd.isNoPrompt,
 		IsRecursive: *cmd.isRecursive,
 		Mounts:      mountPoints,
+		NoClobber:   *cmd.noClobber,
+		Path:        path,
 		Sources:     sources,
 	}).Push())
 }

--- a/commands.go
+++ b/commands.go
@@ -27,6 +27,8 @@ var (
 )
 
 type Options struct {
+	// When set prevents overwriting of stale content
+	NoClobber   bool
 	Path        string
 	IsNoPrompt  bool
 	IsRecursive bool

--- a/pull.go
+++ b/pull.go
@@ -53,7 +53,7 @@ func (g *Commands) playPullChangeList(cl []*Change, exports []string) (err error
 		// play the changes
 		// TODO: add timeouts
 		for _, c := range next {
-			switch c.Op() {
+			switch c.Op(g.opts.NoClobber) {
 			case OpMod:
 				go g.localMod(&wg, c, exports)
 			case OpAdd:

--- a/push.go
+++ b/push.go
@@ -33,7 +33,7 @@ func (g *Commands) Push() (err error) {
 func (g *Commands) playPushChangeList(cl []*Change) (err error) {
 	g.taskStart(len(cl))
 	for _, c := range cl {
-		switch c.Op() {
+		switch c.Op(g.opts.NoClobber) {
 		case OpMod:
 			g.remoteMod(c)
 		case OpAdd:


### PR DESCRIPTION
Prevents overwriting of data and only permits additions. Modifications and deletions are ignored.
Used in push and push e.g:
drive push -no-clobber
drive pull -no-clobber
