### PR TITLE
init: Cleanup if authorization is aborted

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -97,9 +98,21 @@ func Discover(currentAbsPath string) (context *Context, err error) {
 	return
 }
 
-func Initialize(absPath string) (c *Context, err error) {
-	p := gdPath(absPath)
-	if err = os.MkdirAll(p, 0755); err != nil {
+func Initialize(absPath string) (pathGD string, firstInit bool, c *Context, err error) {
+	pathGD = gdPath(absPath)
+	sInfo, sErr := os.Stat(pathGD)
+	if sErr != nil {
+		if os.IsNotExist(sErr) {
+			firstInit = true
+		} else if !os.IsExist(sErr) { // An err not related to path existance
+			return
+		}
+	}
+	if sInfo != nil && !sInfo.IsDir() {
+		err = fmt.Errorf("%s is not a directory", pathGD)
+		return
+	}
+	if err = os.MkdirAll(pathGD, 0755); err != nil {
 		return
 	}
 	c = &Context{AbsPath: absPath}

--- a/diff.go
+++ b/diff.go
@@ -37,11 +37,11 @@ func (g *Commands) Diff() (err error) {
 		return
 	}
 
-    var diffUtilPath string
-    diffUtilPath, err = exec.LookPath("diff")
-    if err != nil {
-        return
-    }
+	var diffUtilPath string
+	diffUtilPath, err = exec.LookPath("diff")
+	if err != nil {
+		return
+	}
 
 	for _, c := range cl {
 		dErr := g.perDiff(c, diffUtilPath, ".")
@@ -53,14 +53,14 @@ func (g *Commands) Diff() (err error) {
 }
 
 func sysHasDiff() bool {
-    _, err := exec.LookPath("diff")
-    return err == nil
+	_, err := exec.LookPath("diff")
+	return err == nil
 }
 
 func (g *Commands) perDiff(change *Change, diffProgPath, cwd string) (err error) {
-    defer func() {
-        fmt.Println(Ruler)
-    }()
+	defer func() {
+		fmt.Println(Ruler)
+	}()
 
 	l, r := change.Src, change.Dest
 	if l == nil && r == nil {
@@ -138,18 +138,18 @@ func (g *Commands) perDiff(change *Change, diffProgPath, cwd string) (err error)
 		return
 	}
 
-    fmt.Printf("%s\n%s %s\n", Ruler, l.Name, r.Name)
+	fmt.Printf("%s\n%s %s\n", Ruler, l.Name, r.Name)
 
-    diffCmd := exec.Cmd {
-        Args: []string{ diffProgPath, l.BlobAt, frTmp.Name() },
-        Dir: cwd,
-        Path: diffProgPath,
-        Stdin: nil,
-        Stdout: os.Stdout,
-        Stderr: os.Stderr,
-    }
+	diffCmd := exec.Cmd{
+		Args:   []string{diffProgPath, l.BlobAt, frTmp.Name()},
+		Dir:    cwd,
+		Path:   diffProgPath,
+		Stdin:  nil,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
 
-    // Normally when elements differ diff returns a non-zero code
-    _ = diffCmd.Run()
+	// Normally when elements differ diff returns a non-zero code
+	_ = diffCmd.Run()
 	return
 }


### PR DESCRIPTION
    init: Cleanup if authorization is aborted
    
    Scenarios for if the init authorization is cancelled:
    + Init has been invoked in this directory before,
      in this case do nothing.
    + This is the first initializing, in this case cleanup.