### PR TITLE
piping: support stdin and stdout sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Note: To ignore checksum verification during a pull:
 $ drive pull -ignore-checksum
 ```
 
+drive also supports piping pulled content to stdout which can be accomplished by:
+
+```shell
+$ drive pull -piped path1 path2
+```
 
 #### Exporting Docs
 
@@ -159,6 +164,13 @@ For safety with non clobberable changes i.e only additions:
 ```shell
 $ drive push -no-clobber
 ```
+
+drive also supports pushing content piped from stdin which can be accomplished by:
+
+```shell
+$ drive push -piped path
+```
+
 
 + Due to the reasons explained in the pull section, drive should be able to warn you in case of total clobbers on data. To turn off this behaviour/safety, pass in the `-force` flag i.e:
 

--- a/src/commands.go
+++ b/src/commands.go
@@ -60,6 +60,8 @@ type Options struct {
 	// TypeMask contains the result of setting different type bits e.g
 	// Folder to search only for folders etc.
 	TypeMask int
+	// Piped when set means to infer content to or from stdin
+	Piped bool
 }
 
 type Commands struct {

--- a/src/pull.go
+++ b/src/pull.go
@@ -82,6 +82,7 @@ func (g *Commands) PullPiped() (err error) {
 		}
 
 		if hasExportLinks(rem) {
+            fmt.Printf("'%s' is a GoogleDoc/Sheet document cannot be pulled from raw, only exported.\n", relToRootPath)
 			continue
 		}
 		blobHandle, dlErr := g.rem.Download(rem.Id, "")

--- a/src/push.go
+++ b/src/push.go
@@ -118,6 +118,12 @@ func (g *Commands) PushPiped() (err error) {
 		if resErr != nil && resErr != ErrPathNotExists {
 			return resErr
 		}
+
+		if hasExportLinks(rem) {
+            fmt.Printf("'%s' is a GoogleDoc/Sheet document cannot be pushed to raw.\n", relToRootPath)
+			continue
+		}
+
 		base := filepath.Base(relToRootPath)
 		local := fauxLocalFile(base)
 		if rem == nil {

--- a/src/remote.go
+++ b/src/remote.go
@@ -409,13 +409,7 @@ type upsertOpt struct {
 	ignoreChecksum bool
 }
 
-func (r *Remote) UpsertByComparison(args *upsertOpt) (f *File, err error) {
-	var body io.Reader
-	body, err = os.Open(args.fsAbsPath)
-	if err != nil && !args.src.IsDir {
-		return
-	}
-
+func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, err error) {
 	uploaded := &drive.File{
 		// Must ensure that the path is prepared for a URL upload
 		Title:   urlToPath(args.src.Name, false),
@@ -471,6 +465,15 @@ func (r *Remote) UpsertByComparison(args *upsertOpt) (f *File, err error) {
 		return
 	}
 	return NewRemoteFile(uploaded), nil
+}
+
+func (r *Remote) UpsertByComparison(args *upsertOpt) (f *File, err error) {
+	var body io.Reader
+	body, err = os.Open(args.fsAbsPath)
+	if err != nil && !args.src.IsDir {
+		return
+	}
+	return r.upsertByComparison(body, args)
 }
 
 func (r *Remote) findShared(p []string) (chan *File, error) {

--- a/src/types.go
+++ b/src/types.go
@@ -117,6 +117,15 @@ func NewLocalFile(absPath string, f os.FileInfo) *File {
 	}
 }
 
+func fauxLocalFile(relToRootPath string) *File {
+	return &File{
+		Id:    "",
+		Name:  relToRootPath,
+		IsDir: false,
+		Size:  0,
+	}
+}
+
 type Change struct {
 	Dest           *File
 	Parent         string


### PR DESCRIPTION
This PR addresses feature request https://github.com/odeke-em/drive/issues/62.
It allows for content to be piped from stdin to a path e.g
```shell
$ cat banx/Makefile | drive push -piped foxy.txt
```

```shell
$ drive pull -piped names.txt > ~/Desktop/records/names.txt
```
Since this code contains source that caused #68 PR #69's code is needed to integrate so as to avoid the noise from ".gd/credentials.json" path not found. The hardcore can just keep removing the ".gd/indices" files and keep testing out this code.