### PR TITLE
ignore-conflict flag added

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ $ drive pull -force
 
 + Note:
   In relation to [#57](https://github.com/odeke-em/drive/issues/57) and [@rakyll's #49](https://github.com/rakyll/drive/issues/49).
-   A couple of scenarios in which data was getting totally clobbered and unrecoverable, drive now tries to play it safe and warn you if your data could potentially be lost e.g during a to-disk clobber for which you have no backup. At least with a push you have the luxury of untrashing content. To disable this safety, run drive with flag `-force` e.g:
+   A couple of scenarios in which data was getting totally clobbered and unrecoverable, drive now tries to play it safe and warn you if your data could potentially be lost e.g during a to-disk clobber for which you have no backup. At least with a push you have the luxury of untrashing content. To disable this safety, run drive with flag `-ignore-conflict` e.g:
 
 ```shell
-$ drive pull -force collaboration_documents
+$ drive pull -ignore-conflict collaboration_documents
 ```
 
 Playing the safety card even more, if you want to get changes that are non clobberable ie only additions
@@ -172,7 +172,7 @@ $ drive push -piped path
 ```
 
 
-+ Due to the reasons explained in the pull section, drive should be able to warn you in case of total clobbers on data. To turn off this behaviour/safety, pass in the `-force` flag i.e:
++ Due to the reasons explained in the pull section, drive should be able to warn you in case of total clobbers on data. To turn off this behaviour/safety, pass in the `-ignore-conflict` flag i.e:
 
 ```shell
 $ drive push -force sure_of_content

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -228,6 +228,7 @@ type pullCmd struct {
 	noClobber      *bool
 	recursive      *bool
 	ignoreChecksum *bool
+	ignoreConflict *bool
 	piped          *bool
 }
 
@@ -240,6 +241,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.hidden = fs.Bool("hidden", false, "allows pulling of hidden paths")
 	cmd.force = fs.Bool("force", false, "forces a pull even if no changes present")
 	cmd.ignoreChecksum = fs.Bool(drive.CLIOptionIgnoreChecksum, false, drive.DescIgnoreChecksum)
+	cmd.ignoreConflict = fs.Bool(drive.CLIOptionIgnoreConflict, false, drive.DescIgnoreConflict)
 	cmd.exportsDir = fs.String("export-dir", "", "directory to place exports")
 	cmd.piped = fs.Bool("piped", false, "if true, read content from stdin")
 
@@ -267,6 +269,7 @@ func (cmd *pullCmd) Run(args []string) {
 		Force:          *cmd.force,
 		Hidden:         *cmd.hidden,
 		IgnoreChecksum: *cmd.ignoreChecksum,
+		IgnoreConflict: *cmd.ignoreConflict,
 		NoPrompt:       *cmd.noPrompt,
 		NoClobber:      *cmd.noClobber,
 		Path:           path,
@@ -297,6 +300,7 @@ type pushCmd struct {
 	// attempted on .[gif, jpg, pdf, png] uploads
 	ocr            *bool
 	ignoreChecksum *bool
+	ignoreConflict *bool
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -307,9 +311,10 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.force = fs.Bool("force", false, "forces a push even if no changes present")
 	cmd.mountedPush = fs.Bool("m", false, "allows pushing of mounted paths")
 	cmd.convert = fs.Bool("convert", false, "toggles conversion of the file to its appropriate Google Doc format")
-	cmd.ignoreChecksum = fs.Bool(drive.CLIOptionIgnoreChecksum, false, drive.DescIgnoreChecksum)
 	cmd.ocr = fs.Bool("ocr", false, "if true, attempt OCR on gif, jpg, pdf and png uploads")
 	cmd.piped = fs.Bool("piped", false, "if true, read content from stdin")
+	cmd.ignoreChecksum = fs.Bool(drive.CLIOptionIgnoreChecksum, false, drive.DescIgnoreChecksum)
+	cmd.ignoreConflict = fs.Bool(drive.CLIOptionIgnoreConflict, false, drive.DescIgnoreConflict)
 	return fs
 }
 
@@ -369,6 +374,7 @@ func (cmd *pushCmd) createPushOptions() *drive.Options {
 		TypeMask:       mask,
 		Piped:          *cmd.piped,
 		IgnoreChecksum: *cmd.ignoreChecksum,
+		IgnoreConflict: *cmd.ignoreConflict,
 		Recursive:      *cmd.recursive,
 	}
 }

--- a/src/changes.go
+++ b/src/changes.go
@@ -328,15 +328,14 @@ func sift(changes []*Change) (nonConflicts, conflicts []*Change) {
 }
 
 func conflictsPersist(conflicts []*Change) bool {
-	conflictCount := len(conflicts)
-	if conflictCount >= 1 {
-		fmt.Printf("These %d file(s) would be overwritten. Use -%s to override this behaviour\n", conflictCount, ForceKey)
-		for _, conflict := range conflicts {
-			fmt.Println(conflict.Path)
-		}
-		return true
+	return len(conflicts) >= 1
+}
+
+func warnConflictsPersist(conflicts []*Change) {
+	fmt.Printf("These %d file(s) would be overwritten. Use -%s to override this behaviour\n", len(conflicts), CLIOptionIgnoreConflict)
+	for _, conflict := range conflicts {
+		fmt.Println(conflict.Path)
 	}
-	return false
 }
 
 func printChanges(changes []*Change, reduce bool) {

--- a/src/commands.go
+++ b/src/commands.go
@@ -42,6 +42,8 @@ type Options struct {
 	// IgnoreChecksum when set avoids the step
 	// of comparing checksums as a final check.
 	IgnoreChecksum bool
+	// IgnoreConflict when set turns off the conflict resolution safety.
+	IgnoreConflict bool
 	// Allows listing of content in trash
 	InTrash bool
 	Meta    *map[string][]string

--- a/src/help.go
+++ b/src/help.go
@@ -69,10 +69,12 @@ const (
 	DescIgnoreChecksum = "avoids computation of checksums as a final check." +
 		"\nUse cases may include:\n\t* when you are low on bandwidth e.g SSHFS." +
 		"\n\t* Are on a low power device"
+	DescIgnoreConflict = "turns off the conflict resolution safety"
 )
 
 const (
 	CLIOptionIgnoreChecksum = "ignore-checksum"
+	CLIOptionIgnoreConflict = "ignore-conflict"
 )
 
 var skipChecksumNote = fmt.Sprintf(


### PR DESCRIPTION
This flag is necessary to handle conflicts as opposed to
using -force which instead would push everything.

This PR addresses #66 