### PR TITLE
Copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,18 @@ To get help for all the commands
 $ drive help all
 ```
 
+### Copying
+
+drive allows you to copy content remotely without having to explicitly download and then reupload.
+
+```shell
+$ drive copy -r blobStore.py mnt flagging
+```
+
+```shell
+$ drive copy blobStore.py blobStoreDuplicated.py
+```
+
 ## Why another Google Drive client?
 
 Background sync is not just hard, it is stupid. My technical and philosophical rants about why it is not worth to implement:
@@ -426,5 +438,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -41,6 +41,7 @@ func main() {
 	runtime.GOMAXPROCS(int(maxProcs))
 
 	command.On(drive.AboutKey, drive.DescAbout, &aboutCmd{}, []string{})
+	command.On(drive.CopyKey, drive.DescCopy, &copyCmd{}, []string{})
 	command.On(drive.DiffKey, drive.DescDiff, &diffCmd{}, []string{})
 	command.On(drive.EmptyTrashKey, drive.DescEmptyTrash, &emptyTrashCmd{}, []string{})
 	command.On(drive.FeaturesKey, drive.DescFeatures, &featuresCmd{}, []string{})
@@ -519,6 +520,27 @@ func (cmd *trashCmd) Run(args []string) {
 			Sources: args,
 		}).TrashByMatch())
 	}
+}
+
+type copyCmd struct {
+	recursive *bool
+}
+
+func (cmd *copyCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.recursive = fs.Bool("r", false, "recursive copying")
+	return fs
+}
+
+func (cmd *copyCmd) Run(args []string) {
+	if len(args) < 2 {
+		args = append(args, ".")
+	}
+	sources, context, path := preprocessArgs(args)
+	exitWithError(drive.New(context, &drive.Options{
+		Path:      path,
+		Sources:   sources,
+		Recursive: *cmd.recursive,
+	}).Copy())
 }
 
 type untrashCmd struct {

--- a/src/copy.go
+++ b/src/copy.go
@@ -1,0 +1,109 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrPathNotDir = errors.New("not a directory")
+
+func (g *Commands) Copy() error {
+	argc := len(g.opts.Sources)
+	if argc < 2 {
+		return fmt.Errorf("expecting src [src1....] dest got: %v", g.opts.Sources)
+	}
+
+	sources, dest := g.opts.Sources[:argc-1], g.opts.Sources[argc-1]
+	destFile, err := g.rem.FindByPath(dest)
+	if err != nil && err != ErrPathNotExists {
+		return fmt.Errorf("destination: %s err: %v", dest, err)
+	}
+
+	if destFile != nil && !destFile.IsDir && len(sources) > 1 {
+		return fmt.Errorf("%s: ", dest, ErrPathNotDir)
+	}
+
+	dirCount := 0
+	regCount := 0
+	destId := ""
+	dirDest := false
+	if destFile != nil {
+		destId = destFile.Id
+		dirDest = destFile.IsDir
+	}
+
+	files := make([]*File, len(sources))
+	for i, relToRootPath := range sources {
+		file, err := g.rem.FindByPath(relToRootPath)
+		if err != nil {
+			return err
+		}
+		if !file.IsDir {
+			regCount += 1
+		} else if file.IsDir {
+			if !dirDest {
+				return fmt.Errorf("%s: %v yet %s is a directory",
+					dest, ErrPathNotDir, relToRootPath)
+			}
+			if !g.opts.Recursive {
+				return fmt.Errorf("%s is a folder yet `recursive` is not defined", relToRootPath)
+			}
+			dirCount += 1
+		}
+		if file.Id == destId {
+			return fmt.Errorf("%s and %s are the same file", relToRootPath, dest)
+		}
+
+		files[i] = file
+	}
+
+	if dirDest {
+		destFile, err = g.rem.mkdirAll(dest)
+		if err != nil {
+			return fmt.Errorf("mkdirAll %s: %v", dest, err)
+		}
+	}
+
+	for _, f := range files {
+		copied, err := g.copy(f.Name, f, destFile)
+		fmt.Println(copied, err)
+	}
+
+	return nil
+}
+
+func (g *Commands) copy(destTitle string, src, dest *File) (*File, error) {
+	if !src.IsDir {
+		parentId := ""
+		if destTitle == "" {
+			destTitle = src.Name
+		}
+		if dest != nil && dest.IsDir {
+			parentId = dest.Id
+		}
+		if !src.Copyable {
+			return nil, fmt.Errorf("%s (%s) is not copyable", src.Name, src.Id)
+		}
+		return g.rem.copy(destTitle, src.Id, parentId)
+	} else {
+		content := g.rem.findChildren(src.Id)
+		for file := range content {
+			fmt.Println("Patch me!", file.Name)
+		}
+	}
+	return nil, nil
+}

--- a/src/help.go
+++ b/src/help.go
@@ -21,6 +21,7 @@ import (
 const (
 	AboutKey      = "about"
 	AllKey        = "all"
+	CopyKey       = "copy"
 	DiffKey       = "diff"
 	EmptyTrashKey = "emptytrash"
 	FeaturesKey   = "features"
@@ -44,6 +45,7 @@ const (
 const (
 	DescAbout          = "print out information about your Google drive"
 	DescAll            = "print out the entire help section"
+	DescCopy           = "copy remote paths to a destination"
 	DescDiff           = "compares local files with their remote equivalent"
 	DescEmptyTrash     = "permanently cleans out your trash"
 	DescFeatures       = "returns information about the features of your drive"
@@ -79,6 +81,9 @@ var skipChecksumNote = fmt.Sprintf(
 var docMap = map[string][]string{
 	AboutKey: []string{
 		DescAbout,
+	},
+	CopyKey: []string{
+		DescCopy,
 	},
 	DiffKey: []string{
 		DescDiff, "Accepts multiple remote paths for line by line comparison",

--- a/src/push.go
+++ b/src/push.go
@@ -236,10 +236,18 @@ func lonePush(g *Commands, parent, absPath, path string) (cl []*Change, err erro
 	return g.resolveChangeListRecv(true, parent, absPath, r, l)
 }
 
-func (g *Commands) parentPather(absPath string) string {
+func (g *Commands) pathSplitter(absPath string) (dir, base string) {
 	p := strings.Split(absPath, "/")
-	p = append([]string{"/"}, p[:len(p)-1]...)
-	return gopath.Join(p...)
+	pLen := len(p)
+	base = p[pLen-1]
+	p = append([]string{"/"}, p[:pLen-1]...)
+	dir = gopath.Join(p...)
+	return
+}
+
+func (g *Commands) parentPather(absPath string) string {
+	dir, _ := g.pathSplitter(absPath)
+	return dir
 }
 
 func (g *Commands) remoteMod(change *Change) (err error) {

--- a/src/stat.go
+++ b/src/stat.go
@@ -78,7 +78,8 @@ func (g *Commands) Stat() error {
 }
 
 func prettyPermission(perm *drive.Permission) {
-	fmt.Printf("\n*\nName: %v <%s>\nRole: %v\nAccountType: %v\n*\n", perm.Name, perm.EmailAddress, perm.Role, perm.Type)
+	fmt.Printf("\n*\nName: %v <%s>\nRole: %v\nAccountType: %v\n*\n",
+		perm.Name, perm.EmailAddress, perm.Role, perm.Type)
 }
 
 func (g *Commands) stat(relToRootPath string, file *File) chan *keyValue {
@@ -103,7 +104,13 @@ func (g *Commands) stat(relToRootPath string, file *File) chan *keyValue {
 			return
 		}
 
-		fmt.Printf("\n\033[92m%s\033[00m\nFileId: %s\nSize: %v\n", relToRootPath, file.Id, prettyBytes(file.Size))
+		dirType := "file"
+		if file.IsDir {
+			dirType = "folder"
+		}
+
+		fmt.Printf("\n\033[92m%s\033[00m\nFileId: %s\nSize: %v\nDirType: %s\nMimeType: %s\nModTime: %s\n",
+			relToRootPath, file.Id, prettyBytes(file.Size), dirType, file.MimeType, file.ModTime)
 		for _, perm := range perms {
 			prettyPermission(perm)
 		}

--- a/src/types.go
+++ b/src/types.go
@@ -243,7 +243,6 @@ func md5Checksum(f *File) string {
 	}
 	checksum := fmt.Sprintf("%x", h.Sum(nil))
 	if f.CacheChecksum {
-		// fmt.Println("CACHING CHECKSUM", checksum, f.Name)
 		f.Md5Checksum = checksum
 	}
 	return checksum

--- a/src/types.go
+++ b/src/types.go
@@ -65,6 +65,8 @@ type File struct {
 	Size        int64
 	Etag        string
 	Shared      bool
+	// Copyable decides if the user has allowed for the file to be copied
+	Copyable bool
 	// UserPermission contains the permissions for the authenticated user on this file
 	UserPermission *drive.Permission
 	// CacheChecksum when set avoids recomputation of checksums
@@ -89,9 +91,32 @@ func NewRemoteFile(f *drive.File) *File {
 		Md5Checksum: f.Md5Checksum,
 		MimeType:    f.MimeType,
 		ModTime:     mtime,
+		Copyable:    f.Copyable,
 		// We must convert each title to match that on the FS.
 		Name:           urlToPath(f.Title, true),
 		Size:           f.FileSize,
+		Shared:         f.Shared,
+		UserPermission: f.UserPermission,
+		Version:        f.Version,
+		OwnerNames:     f.OwnerNames,
+		Permissions:    f.Permissions,
+	}
+}
+
+func DupFile(f *File) *File {
+	return &File{
+		BlobAt:      f.BlobAt,
+		Etag:        f.Etag,
+		ExportLinks: f.ExportLinks,
+		Id:          f.Id,
+		IsDir:       f.IsDir,
+		Md5Checksum: f.Md5Checksum,
+		MimeType:    f.MimeType,
+		ModTime:     f.ModTime,
+		Copyable:    f.Copyable,
+		// We must convert each title to match that on the FS.
+		Name:           f.Name,
+		Size:           f.Size,
 		Shared:         f.Shared,
 		UserPermission: f.UserPermission,
 		Version:        f.Version,


### PR DESCRIPTION
Implemented a copy method. This PR is meant to address issue #42.

Sample usage:
```shell
$ drive copy -r a8 blobStore.py mnt assembled
```

```shell
$ drive copy content.jpg archives/photographs/unified
```
This method `copy` is more lenient than the usual FS `cp` as you can see from the last command, you can specify arbitrary nesting and copy should create the appropriate paths for you.

To apply this PR in order to test out this code:
```shell
$ cd $GOPATH/src/github.com/odeke-em/drive
$ git fetch --all
$ git checkout copy
$ go get github.com/odeke-em/drive/cmd/drive
```