### PR TITLE
.driveignore started, similar to a .gitignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
   - [Features](#features)
   - [About](#about)
   - [Help](#help)
+  - [DriveIgnore](#driveignore)
 - [Why another Google Drive client?](#why-another-google-drive-client)
 - [Known issues](#known-issues)
 - [LICENSE](#license)
@@ -387,6 +388,23 @@ $ drive copy -r blobStore.py mnt flagging
 ```shell
 $ drive copy blobStore.py blobStoreDuplicated.py
 ```
+
+### DriveIgnore
+
+drive allows you to specify a '.driveignore' file similar to your .gitignore, in the root
+directory of the mounted drive. Blank lines and those prefixed by '#' are considered as comments and skipped.
+
+For example:
+
+```shell
+$ cat << $ >> .driveignore
+> # My drive ignore file
+> .gd
+> *.so
+> *.swp
+> $
+```
+
 
 ## Why another Google Drive client?
 

--- a/README.md
+++ b/README.md
@@ -400,10 +400,12 @@ For example:
 $ cat << $ >> .driveignore
 > # My drive ignore file
 > .gd
-> *.so
-> *.swp
+> .so
+> .swp
 > $
 ```
+
+Note: Pattern matching and suffixes are done by regular expression matching so make sure to use a valid regular expression suffix.
 
 
 ## Why another Google Drive client?

--- a/src/changes.go
+++ b/src/changes.go
@@ -178,7 +178,7 @@ func (g *Commands) resolveChangeListRecv(
 		localChildren = make(chan *File)
 		close(localChildren)
 	} else {
-		localChildren, err = list(g.context, p, g.opts.Hidden)
+		localChildren, err = list(g.context, p, g.opts.Hidden, g.opts.IgnoreRegexp)
 		if err != nil {
 			return
 		}

--- a/src/changes.go
+++ b/src/changes.go
@@ -92,6 +92,11 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, isPush bool) (cl 
 		}
 	}
 
+	if g.opts.IgnoreRegexp != nil && g.opts.IgnoreRegexp.Match([]byte(relToRoot)) {
+		fmt.Printf("\n'%s' is set to be ignored yet is being processed. Use `%s` to override this\n", relToRoot, ForceKey)
+		return cl, nil
+	}
+
 	localinfo, _ := os.Stat(fsPath)
 	if localinfo != nil {
 		l = NewLocalFile(fsPath, localinfo)
@@ -134,6 +139,7 @@ func (g *Commands) differ(a, b *File) bool {
 func (g *Commands) resolveChangeListRecv(
 	isPush bool, d, p string, r *File, l *File) (cl []*Change, err error) {
 	var change *Change
+
 	if isPush {
 		// Handle the case of doc files for which we don't have a direct download
 		// url but have exportable links. These files should not be clobbered on push

--- a/src/commands.go
+++ b/src/commands.go
@@ -91,14 +91,9 @@ func New(context *config.Context, opts *Options) *Commands {
 		// should always start with /
 		opts.Path = path.Clean(path.Join("/", opts.Path))
 
-		ignoresPath := filepath.Join(context.AbsPath, DriveIgnoreSuffix)
-		clauses, err := readCommentedFile(ignoresPath, "#")
-
-		if err == nil {
-			regExComp, regErr := regexp.Compile(strings.Join(clauses, "|"))
-			if regErr == nil {
-				opts.IgnoreRegexp = regExComp
-			}
+		if !opts.Force {
+			ignoresPath := filepath.Join(context.AbsPath, DriveIgnoreSuffix)
+			opts.IgnoreRegexp = readCommentedFileCompileRegexp(ignoresPath)
 		}
 	}
 	return &Commands{
@@ -106,6 +101,18 @@ func New(context *config.Context, opts *Options) *Commands {
 		rem:     r,
 		opts:    opts,
 	}
+}
+
+func readCommentedFileCompileRegexp(p string) *regexp.Regexp {
+	clauses, err := readCommentedFile(p, "#")
+	if err != nil {
+		return nil
+	}
+	regExComp, regErr := regexp.Compile(strings.Join(clauses, "|"))
+	if regErr != nil {
+		return nil
+	}
+	return regExComp
 }
 
 func (g *Commands) taskStart(numOfTasks int) {

--- a/src/misc.go
+++ b/src/misc.go
@@ -14,7 +14,11 @@
 
 package drive
 
-import "strings"
+import (
+	"bufio"
+	"os"
+	"strings"
+)
 
 func remotePathSplit(p string) (dir, base string) {
 	// Avoiding use of filepath.Split because of bug with trailing "/" not being stripped
@@ -66,4 +70,29 @@ func commonPrefix(values ...string) string {
 		prefix[i] = min[i]
 	}
 	return string(prefix)
+}
+
+func readCommentedFile(p, comment string) (clauses []string, err error) {
+	f, fErr := os.Open(p)
+	if fErr != nil || f == nil {
+		err = fErr
+		return
+	}
+
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+
+	for {
+		if !scanner.Scan() {
+			break
+		}
+		line := scanner.Text()
+		line = strings.Trim(line, " ")
+		line = strings.Trim(line, "\n")
+		if strings.HasPrefix(line, comment) || len(line) < 1 {
+			continue
+		}
+		clauses = append(clauses, line)
+	}
+	return
 }

--- a/src/push.go
+++ b/src/push.go
@@ -21,6 +21,7 @@ import (
 	"os/signal"
 	gopath "path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -380,7 +381,7 @@ func (g *Commands) remoteMkdirAll(d string) (file *File, err error) {
 	return parent, parentErr
 }
 
-func list(context *config.Context, p string, hidden bool) (fileChan chan *File, err error) {
+func list(context *config.Context, p string, hidden bool, ignore *regexp.Regexp) (fileChan chan *File, err error) {
 	absPath := context.AbsPathOf(p)
 	var f []os.FileInfo
 	f, err = ioutil.ReadDir(absPath)
@@ -393,6 +394,9 @@ func list(context *config.Context, p string, hidden bool) (fileChan chan *File, 
 	go func() {
 		for _, file := range f {
 			if file.Name() == config.GDDirSuffix {
+				continue
+			}
+			if ignore != nil && ignore.Match([]byte(file.Name())) {
 				continue
 			}
 			if !isHidden(file.Name(), hidden) {


### PR DESCRIPTION
A work in progress to address #82.

A .driveignore file should be placed at the root of the drive. A sample file is:

```shell
# My drive ignore file
.swp
.so
heap
.keys
```