### PR TITLE
nonStatable push.piped

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -177,6 +177,7 @@ func (g *Commands) PushPiped() (err error) {
 			src:            rem,
 			dest:           rem,
 			mask:           g.opts.TypeMask,
+			nonStatable:    true,
 			ignoreChecksum: g.opts.IgnoreChecksum,
 		}
 
@@ -185,9 +186,11 @@ func (g *Commands) PushPiped() (err error) {
 			fmt.Printf("%s: %v\n", relToRootPath, rErr)
 			return rErr
 		}
+
 		if rem == nil {
 			continue
 		}
+
 		index := rem.ToIndex()
 		wErr := g.context.SerializeIndex(index, g.context.AbsPathOf(""))
 

--- a/src/push.go
+++ b/src/push.go
@@ -143,13 +143,11 @@ func (g *Commands) PushPiped() (err error) {
 			return resErr
 		}
 		if rem != nil && !g.opts.Force {
-			fmt.Printf("%s already exists remotely, use `%s` to override this behaviour.\n", relToRootPath, ForceKey)
-			continue
+			return fmt.Errorf("%s already exists remotely, use `%s` to override this behaviour.\n", relToRootPath, ForceKey)
 		}
 
 		if hasExportLinks(rem) {
-			fmt.Printf("'%s' is a GoogleDoc/Sheet document cannot be pushed to raw.\n", relToRootPath)
-			continue
+			return fmt.Errorf("'%s' is a GoogleDoc/Sheet document cannot be pushed to raw.\n", relToRootPath)
 		}
 
 		base := filepath.Base(relToRootPath)

--- a/src/remote.go
+++ b/src/remote.go
@@ -405,6 +405,7 @@ type upsertOpt struct {
 	dest           *File
 	mask           int
 	ignoreChecksum bool
+	nonStatable    bool
 }
 
 func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, err error) {
@@ -453,7 +454,7 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, e
 	}
 
 	if !args.src.IsDir {
-		if args.dest == nil {
+		if args.dest == nil || args.nonStatable {
 			req = req.Media(body)
 		} else if mask := fileDifferences(args.src, args.dest, args.ignoreChecksum); checksumDiffers(mask) {
 			req = req.Media(body)


### PR DESCRIPTION
Always insert media on push piped since stating os.Stdin
is meaningless. The completes the fix for #87.