### PR TITLE
resolveConflict: push toggle, indexVsdestTime cmp

### DIFF
--- a/src/pull.go
+++ b/src/pull.go
@@ -59,7 +59,7 @@ func (g *Commands) Pull() (err error) {
 
 	spin.stop()
 
-	nonConflictsPtr, conflictsPtr := g.resolveConflicts(cl)
+	nonConflictsPtr, conflictsPtr := g.resolveConflicts(cl, false)
 	if conflictsPtr != nil {
 		warnConflictsPersist(g.log, *conflictsPtr)
 		return fmt.Errorf("conflicts have prevented a pull operation")

--- a/src/push.go
+++ b/src/push.go
@@ -77,7 +77,7 @@ func (g *Commands) Push() (err error) {
 
 	spin.stop()
 
-	nonConflictsPtr, conflictsPtr := g.resolveConflicts(cl)
+	nonConflictsPtr, conflictsPtr := g.resolveConflicts(cl, true)
 	if conflictsPtr != nil {
 		warnConflictsPersist(g.log, *conflictsPtr)
 		return fmt.Errorf("conflicts have prevented a push operation")
@@ -113,13 +113,13 @@ func (g *Commands) Push() (err error) {
 	return g.playPushChangeList(nonConflicts)
 }
 
-func (g *Commands) resolveConflicts(cl []*Change) (*[]*Change, *[]*Change) {
+func (g *Commands) resolveConflicts(cl []*Change, push bool) (*[]*Change, *[]*Change) {
 	if g.opts.IgnoreConflict {
 		return &cl, nil
 	}
 
 	nonConflicts, conflicts := sift(cl)
-	resolved, unresolved := resolveConflicts(conflicts, true, g.deserializeIndex)
+	resolved, unresolved := resolveConflicts(conflicts, push, g.deserializeIndex)
 	if conflictsPersist(unresolved) {
 		return &resolved, &unresolved
 	}


### PR DESCRIPTION
+ Fix mistyped 'push' toggle that was alway set to true
irrespective of type of op: push vs pull.
+ Check if indexed.ModTime == dest.ModTime on push.

This PR is meant to address #114 for which a bug manifested because the last indexTime was not being checked against the destination modTime as well as a mistyped 'push' toggle.