### PR TITLE
Listing

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -251,20 +251,11 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	return fs
 }
 
-func nonEmptyStrings(v []string) (splits []string) {
-	for _, elem := range v {
-		if elem != "" {
-			splits = append(splits, elem)
-		}
-	}
-	return
-}
-
 func (cmd *pullCmd) Run(args []string) {
 	sources, context, path := preprocessArgs(args)
 
 	// Filter out empty strings.
-	exports := nonEmptyStrings(strings.Split(*cmd.export, ","))
+	exports := drive.NonEmptyStrings(strings.Split(*cmd.export, ","))
 
 	options := &drive.Options{
 		Exports:        uniqOrderedStr(exports),
@@ -415,7 +406,7 @@ func (cmd *pushCmd) pushMounted(args []string) {
 		}
 	}
 
-	rest = nonEmptyStrings(rest)
+	rest = drive.NonEmptyStrings(rest)
 	context, path := discoverContext(contextArgs)
 	contextAbsPath, err := filepath.Abs(path)
 	exitWithError(err)
@@ -631,7 +622,7 @@ func (cmd *unshareCmd) Run(args []string) {
 	sources, context, path := preprocessArgs(args)
 
 	meta := map[string][]string{
-		"accountType": uniqOrderedStr(nonEmptyStrings(strings.Split(*cmd.accountType, ","))),
+		"accountType": uniqOrderedStr(drive.NonEmptyStrings(strings.Split(*cmd.accountType, ","))),
 	}
 
 	exitWithError(drive.New(context, &drive.Options{
@@ -703,9 +694,9 @@ func (cmd *shareCmd) Run(args []string) {
 
 	meta := map[string][]string{
 		"emailMessage": []string{*cmd.message},
-		"emails":       uniqOrderedStr(nonEmptyStrings(strings.Split(*cmd.emails, ","))),
-		"role":         uniqOrderedStr(nonEmptyStrings(strings.Split(*cmd.role, ","))),
-		"accountType":  uniqOrderedStr(nonEmptyStrings(strings.Split(*cmd.accountType, ","))),
+		"emails":       uniqOrderedStr(drive.NonEmptyStrings(strings.Split(*cmd.emails, ","))),
+		"role":         uniqOrderedStr(drive.NonEmptyStrings(strings.Split(*cmd.role, ","))),
+		"accountType":  uniqOrderedStr(drive.NonEmptyStrings(strings.Split(*cmd.accountType, ","))),
 	}
 
 	mask := drive.NoopOnShare

--- a/src/help.go
+++ b/src/help.go
@@ -45,7 +45,9 @@ const (
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
 
-	ForceKey = "force"
+	ForceKey     = "force"
+	QuitShortKey = "q"
+	QuitLongKey  = "quit"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	MimeTypeJoiner = "-"
+	MimeTypeJoiner      = "-"
+	RemoteDriveRootPath = "My Drive"
 )
 
 var BytesPerKB = float64(1024)
@@ -55,6 +56,14 @@ func newPlayable(freq int64) *playable {
 		reset: spin.Reset,
 		pause: spin.Stop,
 	}
+}
+
+func rootLike(p string) bool {
+	return p == "/" || p == "" || p == "root"
+}
+
+func remoteRootLike(p string) bool {
+	return p == RemoteDriveRootPath
 }
 
 type byteDescription func(b int64) string
@@ -92,6 +101,11 @@ func sepJoin(sep string, args ...string) string {
 	return strings.Join(args, sep)
 }
 
+func sepJoinNonEmpty(sep string, args ...string) string {
+	nonEmpties := NonEmptyStrings(args)
+	return sepJoin(sep, nonEmpties...)
+}
+
 func isHidden(p string, ignore bool) bool {
 	if strings.HasPrefix(p, ".") {
 		return !ignore
@@ -103,7 +117,7 @@ func nextPage() bool {
 	var input string
 	fmt.Printf("---More---")
 	fmt.Scanln(&input)
-	if len(input) >= 1 && strings.ToLower(input[:1]) == "q" {
+	if len(input) >= 1 && strings.ToLower(input[:1]) == QuitShortKey {
 		return false
 	}
 	return true
@@ -214,6 +228,15 @@ func readCommentedFile(p, comment string) (clauses []string, err error) {
 			continue
 		}
 		clauses = append(clauses, line)
+	}
+	return
+}
+
+func NonEmptyStrings(v []string) (splits []string) {
+	for _, elem := range v {
+		if elem != "" {
+			splits = append(splits, elem)
+		}
 	}
 	return
 }

--- a/src/remote.go
+++ b/src/remote.go
@@ -201,10 +201,6 @@ func (r *Remote) FindById(id string) (file *File, err error) {
 	return NewRemoteFile(f), nil
 }
 
-func rootLike(p string) bool {
-	return p == "/" || p == "" || p == "root"
-}
-
 func (r *Remote) findByPath(p string, trashed bool) (*File, error) {
 	if rootLike(p) {
 		return r.FindById("root")

--- a/src/trash.go
+++ b/src/trash.go
@@ -37,7 +37,7 @@ func (g *Commands) EmptyTrash() error {
 	spin.play()
 	defer spin.stop()
 
-	if !g.breadthFirst(rootFile, "", "", -1, 0, true, spin) {
+	if !g.breadthFirst(rootFile, "/", -1, 0, true, spin) {
 		return nil
 	}
 


### PR DESCRIPTION
Fixing invalid prints during listing firstly because relToRoot for some reason was being resolved relative to the cwd and not to root, so unnecessary conversion required.
Secondly joining of paths was tripping out because root is usually '/', joining '/' with fileName with separator '/' results in an invalid path.
This PR addresses https://github.com/odeke-em/drive/issues/97
