### PR TITLE
about/help: provide more diagnostic information

### DIFF
--- a/src/help.go
+++ b/src/help.go
@@ -16,6 +16,8 @@ package drive
 
 import (
 	"fmt"
+
+	"github.com/odeke-em/xon/pkger/src"
 )
 
 const (
@@ -45,10 +47,11 @@ const (
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
 
-	ForceKey     = "force"
-	QuietKey     = "quiet"
-	QuitShortKey = "q"
-	QuitLongKey  = "quit"
+	ForceKey         = "force"
+	QuietKey         = "quiet"
+	QuitShortKey     = "q"
+	QuitLongKey      = "quit"
+	DriveRepoRelPath = "github.com/odeke-em/drive"
 )
 
 const (
@@ -184,7 +187,12 @@ func ShowAllDescriptions() {
 }
 
 func PrintVersion() {
-	fmt.Printf("drive version %s\n", Version)
+	fmt.Printf("drive version %s", Version)
+	pkgInfo, err := pkger.Recon(DriveRepoRelPath)
+	if err == nil && pkgInfo != nil {
+		fmt.Printf("\n%s", pkgInfo)
+	}
+	fmt.Println()
 }
 
 func ShowDescription(topic string) {


### PR DESCRIPTION
Provide by default information like Go version, commit hash,
OS which is usually neglected during bug reports and has
to be reminded to the issue reporters.

This PR is meant to address issue https://github.com/odeke-em/drive/issues/138

Sample output
![screen shot 2015-04-01 at 11 08 10 pm](https://cloud.githubusercontent.com/assets/4898263/6958129/8219e974-d8c4-11e4-9036-76db69443491.png)
