### PR TITLE
progress: byte by byte progress info.

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -293,10 +293,10 @@ func merge(remotes, locals chan *File) (merged []*dirList) {
 	return
 }
 
-func reduceToSize(changes []*Change, isPush bool) (totalSize int64) {
+func reduceToSize(changes []*Change, fromSrc bool) (totalSize int64) {
 	totalSize = 0
 	for _, c := range changes {
-		if isPush {
+		if fromSrc {
 			if c.Src != nil {
 				totalSize += c.Src.Size
 			}

--- a/src/commands.go
+++ b/src/commands.go
@@ -144,9 +144,21 @@ func readCommentedFileCompileRegexp(p string) *regexp.Regexp {
 	return regExComp
 }
 
-func (g *Commands) taskStart(numOfTasks int) {
-	if numOfTasks > 0 {
-		g.progress = pb.StartNew(numOfTasks)
+func (g *Commands) taskStart(tasks int64) {
+	if tasks > 0 {
+		g.progress = newProgressBar(tasks)
+	}
+}
+
+func newProgressBar(total int64) *pb.ProgressBar {
+	pbf := pb.New64(total)
+	pbf.Start()
+	return pbf
+}
+
+func (g *Commands) taskAdd(n int64) {
+	if g.progress != nil {
+		g.progress.Add64(n)
 	}
 }
 

--- a/src/trash.go
+++ b/src/trash.go
@@ -155,7 +155,8 @@ func (g *Commands) reduce(args []string, toTrash bool) error {
 }
 
 func (g *Commands) playTrashChangeList(cl []*Change, toTrash bool) (err error) {
-	g.taskStart(len(cl))
+	trashSize := reduceToSize(cl, !toTrash)
+	g.taskStart(int64(len(cl)) + trashSize)
 
 	var f = g.remoteUntrash
 	if toTrash {


### PR DESCRIPTION
Allows for constant updates byte by byte to shown.
This fixes the old style of progress reporting that
would only update once a job was completed. Previously
could not work for large jobs.

This PR addresses issues https://github.com/odeke-em/drive/issues/108 and https://github.com/odeke-em/drive/issues/23