### PR TITLE
Static build

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ go 1.2 or higher is required. See [here](https://golang.org/doc/install) for ins
 
 ## Installation
 
+
+* Note:
+In order to address [issue #138](https://github.com/odeke-em/drive/issues/138), where debug information should be bundled with the binary, you'll need to run:
+
+```shell
+$ go get -u github.com/odeke-em/drive-gen && drive-gen
+```
+Otherwise:
+
 To install from the latest source, run:
 
 ```shell

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/odeke-em/drive/config"
+	"github.com/odeke-em/drive/gen"
 	"github.com/odeke-em/drive/src"
 	"github.com/rakyll/command"
 )
@@ -114,7 +115,7 @@ func (cmd *versionCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 }
 
 func (cmd *versionCmd) Run(args []string) {
-	drive.PrintVersion()
+	fmt.Printf("drive version: %s\n%s\n", drive.Version, generated.PkgInfo)
 	exitWithError(nil)
 }
 

--- a/gen/generated.go
+++ b/gen/generated.go
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 
-// This file was auto-generated at 2015-04-15 01:09:07.52 -0600 MDT
+// This file was auto-generated at 2015-04-15 01:38:47.768 -0600 MDT
 // Edits will be overwritten!
 
-package drive
+
+package generated
 
 import "github.com/odeke-em/xon/pkger/src"
 
-var pkgInfo = &pkger.PkgInfo {
-	CommitHash: "<BUILD_COMMIT_HASH>",
+var PkgInfo = &pkger.PkgInfo {
+	CommitHash: "<CURRENT_COMMIT>",
 	GoVersion: "<GO_VERSION>",
 	OsInfo: "<OS_INFO>",
 }

--- a/src/about.go
+++ b/src/about.go
@@ -21,7 +21,7 @@ import (
 	"github.com/odeke-em/log"
 )
 
-const Version = "0.1.7"
+const Version = "0.1.8"
 
 const (
 	Barely = iota

--- a/src/about.go
+++ b/src/about.go
@@ -39,7 +39,6 @@ const (
 )
 
 func (g *Commands) About(mask int) (err error) {
-	defer PrintVersion()
 	if mask == AboutNone {
 		return nil
 	}

--- a/src/generated.go
+++ b/src/generated.go
@@ -13,16 +13,15 @@
 // limitations under the License.
 
 
-// This file was auto-generated at 2015-04-15 01:06:46.209 -0600 MDT
+// This file was auto-generated at 2015-04-15 01:09:07.52 -0600 MDT
 // Edits will be overwritten!
-
 
 package drive
 
 import "github.com/odeke-em/xon/pkger/src"
 
 var pkgInfo = &pkger.PkgInfo {
-	CommitHash: "'421071031f6316aed4c900df33c84494725bde9c'",
-	GoVersion: "go1.4.1",
-	OsInfo: "darwin/amd64",
+	CommitHash: "<BUILD_COMMIT_HASH>",
+	GoVersion: "<GO_VERSION>",
+	OsInfo: "<OS_INFO>",
 }

--- a/src/generated.go
+++ b/src/generated.go
@@ -1,0 +1,28 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// This file was auto-generated at 2015-04-15 01:06:46.209 -0600 MDT
+// Edits will be overwritten!
+
+
+package drive
+
+import "github.com/odeke-em/xon/pkger/src"
+
+var pkgInfo = &pkger.PkgInfo {
+	CommitHash: "'421071031f6316aed4c900df33c84494725bde9c'",
+	GoVersion: "go1.4.1",
+	OsInfo: "darwin/amd64",
+}

--- a/src/help.go
+++ b/src/help.go
@@ -16,8 +16,6 @@ package drive
 
 import (
 	"fmt"
-
-	"github.com/odeke-em/xon/pkger/src"
 )
 
 const (
@@ -193,12 +191,7 @@ func ShowAllDescriptions() {
 }
 
 func PrintVersion() {
-	fmt.Printf("drive version %s", Version)
-	pkgInfo, err := pkger.Recon(DriveRepoRelPath)
-	if err == nil && pkgInfo != nil {
-		fmt.Printf("\n%s", pkgInfo)
-	}
-	fmt.Println()
+	fmt.Printf("drive version %s\n%s\n", Version, pkgInfo)
 }
 
 func ShowDescription(topic string) {

--- a/src/help.go
+++ b/src/help.go
@@ -190,10 +190,6 @@ func ShowAllDescriptions() {
 	}
 }
 
-func PrintVersion() {
-	fmt.Printf("drive version %s\n%s\n", Version, pkgInfo)
-}
-
 func ShowDescription(topic string) {
 	if topic == AllKey {
 		ShowAllDescriptions()

--- a/src/help.go
+++ b/src/help.go
@@ -199,6 +199,7 @@ func ShowDescription(topic string) {
 		ShowAllDescriptions()
 		return
 	}
+
 	help, ok := docMap[topic]
 	if !ok {
 		fmt.Printf("Unkown command '%s' type `drive help all` for entire usage documentation\n", topic)


### PR DESCRIPTION
Now has the ability to bundle static information at build time. However changes the build process to be (extract the current repo information and generate the appropriate files then build drive)

```shell
$ go get -u github.com/odeke-em/drive-gen && drive-gen
```

Instead of
```shell
$ go get -u github.com/odeke-em/drive/cmd/drive
```

This PR is meant to address https://github.com/odeke-em/drive/issues/138.