### PR TITLE
Coerced mime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ Note: To use OCR, your account should have this feature. You can find out if you
 $ drive features
 ```
 
+## Note:
+
+In relation to [issue #154](https://github.com/odeke-em/drive/issues/154):
+
+Google Drive might not properly certain files and package them as archives due to incorrect
+mimeType guesses. To coerce a certain mimeType that you'd prefer to assert with Google Drive pushes, use flag `-coerce-mime <short-key>`
+
+```shell
+$ drive push -coerce-mime docx test_doc.docx
+```
+
 ### Publishing
 
 The `pub` command publishes a file or directory globally so that anyone can view it on the web using the link returned.

--- a/README.md
+++ b/README.md
@@ -223,13 +223,12 @@ $ drive features
 
 ## Note:
 
-In relation to [issue #154](https://github.com/odeke-em/drive/issues/154):
+MimeType inference is from the file's extension.
 
-Google Drive might not properly certain files and package them as archives due to incorrect
-mimeType guesses. To coerce a certain mimeType that you'd prefer to assert with Google Drive pushes, use flag `-coerce-mime <short-key>`
+If you would like to coerce a certain mimeType that you'd prefer to assert with Google Drive pushes, use flag `-coerce-mime <short-key>`
 
 ```shell
-$ drive push -coerce-mime docx test_doc.docx
+$ drive push -coerce-mime docx my_test_doc
 ```
 
 ### Publishing

--- a/src/changes.go
+++ b/src/changes.go
@@ -169,6 +169,22 @@ func (g *Commands) differ(a, b *File) bool {
 	return fileDifferences(a, b, g.opts.IgnoreChecksum) == DifferNone
 }
 
+func (g *Commands) coercedMimeKey() (coerced string, ok bool) {
+	if g.opts.Meta == nil {
+		return
+	}
+
+	var values []string
+	dict := *g.opts.Meta
+	values, ok = dict[CoercedMimeKeyKey]
+
+	if len(values) >= 1 {
+		coerced = values[0]
+	}
+
+	return
+}
+
 func (g *Commands) resolveChangeListRecv(
 	isPush bool, d, p string, r *File, l *File) (cl []*Change, err error) {
 	var change *Change

--- a/src/changes.go
+++ b/src/changes.go
@@ -180,6 +180,8 @@ func (g *Commands) coercedMimeKey() (coerced string, ok bool) {
 
 	if len(values) >= 1 {
 		coerced = values[0]
+	} else {
+		ok = false
 	}
 
 	return

--- a/src/help.go
+++ b/src/help.go
@@ -47,11 +47,12 @@ const (
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
 
-	ForceKey         = "force"
-	QuietKey         = "quiet"
-	QuitShortKey     = "q"
-	QuitLongKey      = "quit"
-	DriveRepoRelPath = "github.com/odeke-em/drive"
+	CoercedMimeKeyKey = "coerced-mime"
+	ForceKey          = "force"
+	QuietKey          = "quiet"
+	QuitShortKey      = "q"
+	QuitLongKey       = "quit"
+	DriveRepoRelPath  = "github.com/odeke-em/drive"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	// "path/filepath"
 	"strings"
 
 	spinner "github.com/odeke-em/cli-spinner"
@@ -121,7 +122,7 @@ func sepJoin(sep string, args ...string) string {
 }
 
 func sepJoinNonEmpty(sep string, args ...string) string {
-	nonEmpties := NonEmptyStrings(args)
+	nonEmpties := NonEmptyStrings(args...)
 	return sepJoin(sep, nonEmpties...)
 }
 
@@ -274,11 +275,16 @@ func chunkInt64(v int64) chan int {
 	return chunks
 }
 
-func NonEmptyStrings(v []string) (splits []string) {
+func NonEmptyStrings(v ...string) (splits []string) {
 	for _, elem := range v {
 		if elem != "" {
 			splits = append(splits, elem)
 		}
 	}
 	return
+}
+
+func guessMimeType(p string) string {
+	resolvedMimeType := mimeTypeFromExt(p)
+	return resolvedMimeType
 }

--- a/src/misc.go
+++ b/src/misc.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	// "path/filepath"
+	"regexp"
 	"strings"
 
 	spinner "github.com/odeke-em/cli-spinner"
@@ -283,6 +283,63 @@ func NonEmptyStrings(v ...string) (splits []string) {
 	}
 	return
 }
+
+var regExtStrMap = map[string]string{
+	"csv":   "text/csv",
+	"html?": "text/html",
+	"te?xt": "text/plain",
+
+	"gif":   "image/gif",
+	"png":   "image/png",
+	"svg":   "image/svg+xml",
+	"jpe?g": "image/jpeg",
+
+	"odt": "application/vnd.oasis.opendocument.text",
+	"rtf": "application/rtf",
+	"pdf": "application/pdf",
+
+    "apk": "application/vnd.android.package-archive",
+    "bin": "application/octet-stream",
+
+	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	"pptx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.presentation",
+	"xlsx?": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
+
+var regExtMap = func() map[*regexp.Regexp]string {
+	regMap := make(map[*regexp.Regexp]string)
+	for regStr, mimeType := range regExtStrMap {
+		regExComp, err := regexp.Compile(regStr)
+		if err == nil {
+			regMap[regExComp] = mimeType
+		}
+	}
+	return regMap
+}()
+
+func _mimeTyper() func(string) string {
+	cache := map[string]string{}
+
+	return func(ext string) string {
+		memoized, ok := cache[ext]
+		if ok {
+			return memoized
+		}
+
+		bExt := []byte(ext)
+		for regEx, mimeType := range regExtMap {
+			if regEx != nil && regEx.Match(bExt) {
+				memoized = mimeType
+				break
+			}
+		}
+
+		cache[ext] = memoized
+		return memoized
+	}
+}
+
+var mimeTypeFromExt = _mimeTyper()
 
 func guessMimeType(p string) string {
 	resolvedMimeType := mimeTypeFromExt(p)

--- a/src/push.go
+++ b/src/push.go
@@ -322,7 +322,9 @@ func (g *Commands) remoteMod(change *Change) (err error) {
 
 	coercedMimeKey, ok := g.coercedMimeKey()
 	if ok {
-		args.coercedMimeKey = coercedMimeKey
+		args.mimeKey = coercedMimeKey
+	} else if args.src != nil { // Infer it from the extension
+		args.mimeKey = filepath.Ext(args.src.Name)
 	}
 
 	rem, err := g.rem.UpsertByComparison(&args)

--- a/src/push.go
+++ b/src/push.go
@@ -320,6 +320,11 @@ func (g *Commands) remoteMod(change *Change) (err error) {
 		ignoreChecksum: g.opts.IgnoreChecksum,
 	}
 
+	coercedMimeKey, ok := g.coercedMimeKey()
+	if ok {
+		args.coercedMimeKey = coercedMimeKey
+	}
+
 	rem, err := g.rem.UpsertByComparison(&args)
 	if err != nil {
 		g.log.LogErrf("%s: %v\n", change.Path, err)

--- a/src/remote.go
+++ b/src/remote.go
@@ -411,6 +411,41 @@ type upsertOpt struct {
 	nonStatable    bool
 }
 
+func togglePropertiesInsertCall(req *drive.FilesInsertCall, mask int) *drive.FilesInsertCall {
+	// TODO: if ocr toggled respect the quota limits if ocr is enabled.
+	if ocr(mask) {
+		req = req.Ocr(true)
+	}
+	if convert(mask) {
+		req = req.Convert(true)
+	}
+	if pin(mask) {
+		req = req.Pinned(true)
+	}
+	if indexContent(mask) {
+		req = req.UseContentAsIndexableText(true)
+	}
+	return req
+}
+
+func togglePropertiesUpdateCall(req *drive.FilesUpdateCall, mask int) *drive.FilesUpdateCall {
+	// TODO: if ocr toggled respect the quota limits if ocr is enabled.
+	fmt.Println("CONVERT SET", mask)
+	if ocr(mask) {
+		req = req.Ocr(true)
+	}
+	if convert(mask) {
+		req = req.Convert(true)
+	}
+	if pin(mask) {
+		req = req.Pinned(true)
+	}
+	if indexContent(mask) {
+		req = req.UseContentAsIndexableText(true)
+	}
+	return req
+}
+
 func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, mediaInserted bool, err error) {
 	uploaded := &drive.File{
 		// Must ensure that the path is prepared for a URL upload
@@ -426,13 +461,19 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 
 	if args.src.Id == "" {
 		req := r.service.Files.Insert(uploaded)
+
 		if !args.src.IsDir && body != nil {
 			req = req.Media(body)
 			mediaInserted = true
 		}
+
+		// Toggle the respective properties
+		req = togglePropertiesInsertCall(req, args.mask)
+
 		if uploaded, err = req.Do(); err != nil {
 			return
 		}
+
 		f = NewRemoteFile(uploaded)
 		return
 	}
@@ -443,21 +484,6 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 	// We always want it to match up with the local time
 	req.SetModifiedDate(true)
 
-	// Next set all the desired attributes
-	// TODO: if ocr toggled respect the quota limits if ocr is enabled.
-	if ocr(args.mask) {
-		req.Ocr(true)
-	}
-	if convert(args.mask) {
-		req.Convert(true)
-	}
-	if pin(args.mask) {
-		req.Pinned(true)
-	}
-	if indexContent(args.mask) {
-		req.UseContentAsIndexableText(true)
-	}
-
 	if !args.src.IsDir {
 		if args.dest == nil || args.nonStatable {
 			req = req.Media(body)
@@ -467,6 +493,10 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 			req = req.Media(body)
 		}
 	}
+
+	// Next toggle the appropriate properties
+	req = togglePropertiesUpdateCall(req, args.mask)
+
 	if uploaded, err = req.Do(); err != nil {
 		return
 	}

--- a/src/remote.go
+++ b/src/remote.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -68,46 +67,6 @@ var (
 	UnescapedPathSep = fmt.Sprintf("%c", os.PathSeparator)
 	EscapedPathSep   = url.QueryEscape(UnescapedPathSep)
 )
-
-var regExtStrMap = map[string]string{
-	"csv":   "text/csv",
-	"html?": "text/html",
-	"te?xt": "text/plain",
-
-	"gif":   "image/gif",
-	"png":   "image/png",
-	"svg":   "image/svg+xml",
-	"jpe?g": "image/jpeg",
-
-	"odt": "application/vnd.oasis.opendocument.text",
-	"rtf": "application/rtf",
-	"pdf": "application/pdf",
-
-	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"pptx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.presentation",
-	"xlsx?": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-}
-
-var regExtMap = func() map[*regexp.Regexp]string {
-	regMap := make(map[*regexp.Regexp]string)
-	for regStr, mimeType := range regExtStrMap {
-		regExComp, err := regexp.Compile(regStr)
-		if err == nil {
-			regMap[regExComp] = mimeType
-		}
-	}
-	return regMap
-}()
-
-func mimeTypeFromExt(ext string) string {
-	bExt := []byte(ext)
-	for regEx, mimeType := range regExtMap {
-		if regEx != nil && regEx.Match(bExt) {
-			return mimeType
-		}
-	}
-	return ""
-}
 
 type Remote struct {
 	transport    *oauth.Transport
@@ -408,7 +367,7 @@ type upsertOpt struct {
 	dest           *File
 	mask           int
 	ignoreChecksum bool
-	coercedMimeKey string
+	mimeKey        string
 	nonStatable    bool
 }
 
@@ -452,12 +411,13 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 		Title:   urlToPath(args.src.Name, false),
 		Parents: []*drive.ParentReference{&drive.ParentReference{Id: args.parentId}},
 	}
+
 	if args.src.IsDir {
 		uploaded.MimeType = DriveFolderMimeType
 	}
 
-	if args.coercedMimeKey != "" {
-		uploaded.MimeType = guessMimeType(args.coercedMimeKey)
+	if args.mimeKey != "" {
+		uploaded.MimeType = guessMimeType(args.mimeKey)
 	}
 
 	// Ensure that the ModifiedDate is retrieved from local

--- a/src/remote.go
+++ b/src/remote.go
@@ -408,6 +408,7 @@ type upsertOpt struct {
 	dest           *File
 	mask           int
 	ignoreChecksum bool
+	coercedMimeKey string
 	nonStatable    bool
 }
 
@@ -430,7 +431,6 @@ func togglePropertiesInsertCall(req *drive.FilesInsertCall, mask int) *drive.Fil
 
 func togglePropertiesUpdateCall(req *drive.FilesUpdateCall, mask int) *drive.FilesUpdateCall {
 	// TODO: if ocr toggled respect the quota limits if ocr is enabled.
-	fmt.Println("CONVERT SET", mask)
 	if ocr(mask) {
 		req = req.Ocr(true)
 	}
@@ -454,6 +454,10 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 	}
 	if args.src.IsDir {
 		uploaded.MimeType = DriveFolderMimeType
+	}
+
+	if args.coercedMimeKey != "" {
+		uploaded.MimeType = guessMimeType(args.coercedMimeKey)
 	}
 
 	// Ensure that the ModifiedDate is retrieved from local


### PR DESCRIPTION
This is a patch to handle issue #154 in which failure to preprocess mimeTypes leads drive to create archive files for *.doc files. The changes in this PR will entail coercing the mimeType if the user decides so i.e
```shell
$ drive push --coerced-mime docx test_doc.docx
```

This PR also allows for mimeType inference from extensions e.g
```shell
$ drive push tests.docx
```

#### Before
```shell
$ drive stat test_doc.docx

/test_doc.docx
...                   
MimeType             application/zip  
```

#### After
```shell
$ driv stat test_doc.docx

/test_doc.docx
MimeType             application/vnd.openxmlformats-officedocument.wordprocessingml.document
```   