### PR TITLE
clashes: detect and abort on clashes if can

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ $ drive push -piped path
 ```
 
 + Note:
+  * In relation to [#107](https://github.com/odeke-em/drive/issues/107) and numerous other issues related to confusion about clashing paths, drive will abort on trying to deal with clashing names. To turn off this safety, pass in flag `--ignore-name-clash`.
   * In relation to [#57](https://github.com/odeke-em/drive/issues/57) and [@rakyll's #49](https://github.com/rakyll/drive/issues/49).
    A couple of scenarios in which data was getting totally clobbered and unrecoverable, drive now tries to play it safe and warn you if your data could potentially be lost e.g during a to-disk clobber for which you have no backup. At least with a push you have the luxury of untrashing content. To disable this safety, run drive with flag `-ignore-conflict` e.g:
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -261,18 +261,19 @@ func (cmd *statCmd) Run(args []string) {
 }
 
 type pullCmd struct {
-	exportsDir     *string
-	export         *string
-	force          *bool
-	hidden         *bool
-	matches        *bool
-	noPrompt       *bool
-	noClobber      *bool
-	recursive      *bool
-	ignoreChecksum *bool
-	ignoreConflict *bool
-	piped          *bool
-	quiet          *bool
+	exportsDir        *string
+	export            *string
+	force             *bool
+	hidden            *bool
+	matches           *bool
+	noPrompt          *bool
+	noClobber         *bool
+	recursive         *bool
+	ignoreChecksum    *bool
+	ignoreConflict    *bool
+	piped             *bool
+	quiet             *bool
+	ignoreNameClashes *bool
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -285,6 +286,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.force = fs.Bool("force", false, "forces a pull even if no changes present")
 	cmd.ignoreChecksum = fs.Bool(drive.CLIOptionIgnoreChecksum, false, drive.DescIgnoreChecksum)
 	cmd.ignoreConflict = fs.Bool(drive.CLIOptionIgnoreConflict, false, drive.DescIgnoreConflict)
+	cmd.ignoreNameClashes = fs.Bool(drive.CLIOptionIgnoreNameClashes, false, drive.DescIgnoreNameClashes)
 	cmd.exportsDir = fs.String("export-dir", "", "directory to place exports")
 	cmd.matches = fs.Bool("matches", false, "search by prefix")
 	cmd.piped = fs.Bool("piped", false, "if true, read content from stdin")
@@ -311,19 +313,20 @@ func (cmd *pullCmd) Run(args []string) {
 	exports := drive.NonEmptyStrings(strings.Split(*cmd.export, ",")...)
 
 	options := &drive.Options{
-		Exports:        uniqOrderedStr(exports),
-		ExportsDir:     strings.Trim(*cmd.exportsDir, " "),
-		Force:          *cmd.force,
-		Hidden:         *cmd.hidden,
-		IgnoreChecksum: *cmd.ignoreChecksum,
-		IgnoreConflict: *cmd.ignoreConflict,
-		NoPrompt:       *cmd.noPrompt,
-		NoClobber:      *cmd.noClobber,
-		Path:           path,
-		Recursive:      *cmd.recursive,
-		Sources:        sources,
-		Piped:          *cmd.piped,
-		Quiet:          *cmd.quiet,
+		Exports:           uniqOrderedStr(exports),
+		ExportsDir:        strings.Trim(*cmd.exportsDir, " "),
+		Force:             *cmd.force,
+		Hidden:            *cmd.hidden,
+		IgnoreChecksum:    *cmd.ignoreChecksum,
+		IgnoreConflict:    *cmd.ignoreConflict,
+		NoPrompt:          *cmd.noPrompt,
+		NoClobber:         *cmd.noClobber,
+		Path:              path,
+		Recursive:         *cmd.recursive,
+		Sources:           sources,
+		Piped:             *cmd.piped,
+		Quiet:             *cmd.quiet,
+		IgnoreNameClashes: *cmd.ignoreNameClashes,
 	}
 
 	if *cmd.matches {
@@ -348,11 +351,12 @@ type pushCmd struct {
 	convert *bool
 	// ocr when set indicates that Optical Character Recognition should be
 	// attempted on .[gif, jpg, pdf, png] uploads
-	ocr            *bool
-	ignoreChecksum *bool
-	ignoreConflict *bool
-	quiet          *bool
-	coercedMimeKey *string
+	ocr               *bool
+	ignoreChecksum    *bool
+	ignoreConflict    *bool
+	ignoreNameClashes *bool
+	quiet             *bool
+	coercedMimeKey    *string
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -369,6 +373,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.ignoreConflict = fs.Bool(drive.CLIOptionIgnoreConflict, false, drive.DescIgnoreConflict)
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.coercedMimeKey = fs.String(drive.CoercedMimeKeyKey, "", "the mimeType you are trying to coerce this file to be")
+	cmd.ignoreNameClashes = fs.Bool(drive.CLIOptionIgnoreNameClashes, false, drive.DescIgnoreNameClashes)
 	return fs
 }
 
@@ -441,17 +446,18 @@ func (cmd *pushCmd) createPushOptions() *drive.Options {
 	}
 
 	return &drive.Options{
-		Force:          *cmd.force,
-		Hidden:         *cmd.hidden,
-		IgnoreChecksum: *cmd.ignoreChecksum,
-		IgnoreConflict: *cmd.ignoreConflict,
-		NoClobber:      *cmd.noClobber,
-		NoPrompt:       *cmd.noPrompt,
-		Recursive:      *cmd.recursive,
-		Piped:          *cmd.piped,
-		Quiet:          *cmd.quiet,
-		Meta:           &meta,
-		TypeMask:       mask,
+		Force:             *cmd.force,
+		Hidden:            *cmd.hidden,
+		IgnoreChecksum:    *cmd.ignoreChecksum,
+		IgnoreConflict:    *cmd.ignoreConflict,
+		NoClobber:         *cmd.noClobber,
+		NoPrompt:          *cmd.noPrompt,
+		Recursive:         *cmd.recursive,
+		Piped:             *cmd.piped,
+		Quiet:             *cmd.quiet,
+		Meta:              &meta,
+		TypeMask:          mask,
+		IgnoreNameClashes: *cmd.ignoreNameClashes,
 	}
 }
 

--- a/src/commands.go
+++ b/src/commands.go
@@ -77,8 +77,9 @@ type Options struct {
 	Piped bool
 	// Quiet when set toggles only logging of errors to stderrs as
 	// well as reading from stdin in this case stdout is not logged to
-	Quiet       bool
-	StdoutIsTty bool
+	Quiet             bool
+	StdoutIsTty       bool
+	IgnoreNameClashes bool
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -84,12 +84,14 @@ const (
 	DescIgnoreChecksum = "avoids computation of checksums as a final check." +
 		"\nUse cases may include:\n\t* when you are low on bandwidth e.g SSHFS." +
 		"\n\t* Are on a low power device"
-	DescIgnoreConflict = "turns off the conflict resolution safety"
+	DescIgnoreConflict    = "turns off the conflict resolution safety"
+	DescIgnoreNameClashes = "ignore name clashes"
 )
 
 const (
-	CLIOptionIgnoreChecksum = "ignore-checksum"
-	CLIOptionIgnoreConflict = "ignore-conflict"
+	CLIOptionIgnoreChecksum    = "ignore-checksum"
+	CLIOptionIgnoreConflict    = "ignore-conflict"
+	CLIOptionIgnoreNameClashes = "ignore-name-clashes"
 )
 
 var skipChecksumNote = fmt.Sprintf(

--- a/src/pull.go
+++ b/src/pull.go
@@ -99,7 +99,7 @@ func (g *Commands) PullMatches() (err error) {
 
 		ccl, cErr := g.byRemoteResolve(relToRoot, fsPath, match, false)
 		if cErr != nil {
-			continue
+			return cErr
 		}
 
 		cl = append(cl, ccl...)


### PR DESCRIPTION
This is a work in progress to address the issue of name clashes within the same directory. This is because Google Drive allows same-name-different-files within the same folder.
This is meant to address issue https://github.com/odeke-em/drive/issues/107