### PR TITLE
flush tty input buffer before asking users for decisions

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -145,6 +145,7 @@ func nextPage() bool {
 
 func promptForChanges() bool {
 	input := "Y"
+	flushTTYin()
 	fmt.Print("Proceed with the changes? [Y/n]: ")
 	fmt.Scanln(&input)
 	return strings.ToUpper(input) == "Y"

--- a/src/trash.go
+++ b/src/trash.go
@@ -53,6 +53,7 @@ func (g *Commands) EmptyTrash() error {
 		g.log.Logln("Empty trash: (Yn)? ")
 
 		input := "Y"
+		flushTTYin()
 		fmt.Print("Proceed with the changes? [Y/n]: ")
 		fmt.Scanln(&input)
 

--- a/src/tty.go
+++ b/src/tty.go
@@ -1,0 +1,35 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build cgo
+
+package drive
+
+/*
+#include <termios.h>
+#include <unistd.h>
+
+void flush_tty_in() {
+	if (isatty(0))
+		tcflush(0, TCIFLUSH);
+}
+*/
+import "C"
+
+// flushTTYin flushes the input buffer of the tty.
+// Use it before asking the user to make decisions, especially after
+// a long wait.
+func flushTTYin() {
+	C.flush_tty_in()
+}

--- a/src/tty_nocgo.go
+++ b/src/tty_nocgo.go
@@ -1,0 +1,21 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !cgo
+
+package drive
+
+func flushTTYin() {
+	// best effort only
+}


### PR DESCRIPTION
Requires cgo to work, and it only works on Unix.

Fixes #157.