### PR TITLE
delete: implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   - [Touching](#touch)
   - [Trashing and Untrashing](#trashing-and-untrashing)
   - [Emptying the Trash](#emptying-the-trash)
+  - [Deleting](#deleting)
   - [Listing Files](#listing-files)
   - [Stating Files](#stating-files)
   - [Quota](#quota)
@@ -320,6 +321,19 @@ Emptying the trash will permanently delete all trashed files. They will be unrec
 ```shell
 $ drive emptytrash
 ```
+
+### Deleting
+
+Deleting items will PERMANENTLY remove the items from your drive. This operation is irreversible.
+
+```shell
+$ drive delete flux.mp4
+```
+
+```shell
+$ drive delete --matches onyx swp
+```
+
 
 ### Listing Files
 

--- a/src/help.go
+++ b/src/help.go
@@ -24,6 +24,7 @@ const (
 	AboutKey      = "about"
 	AllKey        = "all"
 	CopyKey       = "copy"
+	DeleteKey     = "delete"
 	DiffKey       = "diff"
 	EmptyTrashKey = "emptytrash"
 	FeaturesKey   = "features"
@@ -60,6 +61,7 @@ const (
 	DescAbout          = "print out information about your Google drive"
 	DescAll            = "print out the entire help section"
 	DescCopy           = "copy remote paths to a destination"
+	DescDelete         = "deletes the items permanently. This operation is irreversible"
 	DescDiff           = "compares local files with their remote equivalent"
 	DescEmptyTrash     = "permanently cleans out your trash"
 	DescFeatures       = "returns information about the features of your drive"
@@ -104,6 +106,9 @@ var docMap = map[string][]string{
 	},
 	CopyKey: []string{
 		DescCopy,
+	},
+	DeleteKey: []string{
+		DescDelete,
 	},
 	DiffKey: []string{
 		DescDiff, "Accepts multiple remote paths for line by line comparison",

--- a/src/misc.go
+++ b/src/misc.go
@@ -151,8 +151,16 @@ func nextPage() bool {
 	return true
 }
 
-func promptForChanges() bool {
-	input := prompt(os.Stdin, os.Stdout, "Proceed with the changes? [Y/n]: ")
+func promptForChanges(args ...interface{}) bool {
+	argv := []interface{}{
+		"Proceed with the changes? [Y/n]:",
+	}
+	if len(args) >= 1 {
+		argv = args
+	}
+
+	input := prompt(os.Stdin, os.Stdout, argv...)
+
 	if input == "" {
 		input = YesShortKey
 	}

--- a/src/remote.go
+++ b/src/remote.go
@@ -249,6 +249,10 @@ func (r *Remote) Untrash(id string) error {
 	return err
 }
 
+func (r *Remote) Delete(id string) error {
+	return r.service.Files.Delete(id).Do()
+}
+
 func (r *Remote) idForEmail(email string) (string, error) {
 	perm, err := r.service.Permissions.GetIdForEmail(email).Do()
 	if err != nil {

--- a/src/trash.go
+++ b/src/trash.go
@@ -19,11 +19,15 @@ import (
 )
 
 func (g *Commands) Trash() (err error) {
-	return g.reduce(g.opts.Sources, true)
+	return g.reduceForTrash(g.opts.Sources, true, false)
+}
+
+func (g *Commands) Delete() (err error) {
+	return g.reduceForTrash(g.opts.Sources, true, true)
 }
 
 func (g *Commands) Untrash() (err error) {
-	return g.reduce(g.opts.Sources, false)
+	return g.reduceForTrash(g.opts.Sources, false, false)
 }
 
 func (g *Commands) EmptyTrash() error {
@@ -88,7 +92,7 @@ func (g *Commands) trasher(relToRoot string, toTrash bool) (change *Change, err 
 	return
 }
 
-func (g *Commands) trashByMatch(inTrash bool) error {
+func (g *Commands) trashByMatch(inTrash, permanent bool) error {
 	matches, err := g.rem.FindMatches(g.opts.Path, g.opts.Sources, inTrash)
 	if err != nil {
 		return err
@@ -121,18 +125,22 @@ func (g *Commands) trashByMatch(inTrash bool) error {
 		return nil
 	}
 
-	return g.playTrashChangeList(cl, toTrash)
+	return g.playTrashChangeList(cl, toTrash, permanent)
 }
 
 func (g *Commands) TrashByMatch() error {
-	return g.trashByMatch(false)
+	return g.trashByMatch(false, false)
 }
 
 func (g *Commands) UntrashByMatch() error {
-	return g.trashByMatch(true)
+	return g.trashByMatch(true, false)
 }
 
-func (g *Commands) reduce(args []string, toTrash bool) error {
+func (g *Commands) DeleteByMatch() error {
+	return g.trashByMatch(false, true)
+}
+
+func (g *Commands) reduceForTrash(args []string, toTrash, permanent bool) error {
 	var cl []*Change
 	for _, relToRoot := range args {
 		c, cErr := g.trasher(relToRoot, toTrash)
@@ -147,16 +155,26 @@ func (g *Commands) reduce(args []string, toTrash bool) error {
 	if !ok {
 		return nil
 	}
-	return g.playTrashChangeList(cl, toTrash)
+	if permanent && g.opts.canPrompt() {
+		if !promptForChanges("This operation is irreversible. Continue [Y/N] ") {
+			return nil
+		}
+	}
+	return g.playTrashChangeList(cl, toTrash, permanent)
 }
 
-func (g *Commands) playTrashChangeList(cl []*Change, toTrash bool) (err error) {
+func (g *Commands) playTrashChangeList(cl []*Change, toTrash, permanent bool) (err error) {
 	trashSize, unTrashSize := reduceToSize(cl, SelectDest|SelectSrc)
 	g.taskStart(trashSize + unTrashSize)
 
-	var f = g.remoteUntrash
-	if toTrash {
-		f = g.remoteDelete
+	var fn func(*Change) error
+	if permanent {
+		fn = g.remoteDelete
+	} else {
+		fn = g.remoteUntrash
+		if toTrash {
+			fn = g.remoteTrash
+		}
 	}
 
 	for _, c := range cl {
@@ -164,7 +182,7 @@ func (g *Commands) playTrashChangeList(cl []*Change, toTrash bool) (err error) {
 			continue
 		}
 
-		cErr := f(c)
+		cErr := fn(c)
 		if cErr != nil {
 			g.log.LogErrln(cErr)
 		}


### PR DESCRIPTION
This PR implements the `delete` method to address issue https://github.com/odeke-em/drive/issues/164.

Sample usage:
```shell
emmanuel@lap:~/emm.odeke.drive$ drive push --hidden --force .edits.swp 
Resolving...
+ /.edits.swp
Addition count 1 src: 23.89KB
Proceed with the changes? [Y/n]:y
24459 / 24459 [====================================================] 100.00 % 1s

emmanuel@lap:~/emm.odeke.drive$ drive delete --matches .edits.swp
- /.edits.swp
Deletion count 1 dest: 23.89KB
Proceed with the changes? [Y/n]:n

emmanuel@lap:~/emm.odeke.drive$ drive delete .edits.swp
- /.edits.swp
Deletion count 1 dest: 23.89KB
Proceed with the changes? [Y/n]:n

emmanuel@lap:~/emm.odeke.drive$ drive delete --matches .swp
- /.edits.swp
Deletion count 1 dest: 23.89KB
Proceed with the changes? [Y/n]:y
24459 / 24459 [=====================================================] 100.00 % 0

emmanuel@lap:~/emm.odeke.drive$ drive stat .edist.swp
^Cemmanuel@lap:~/emm.odeke.drive$ drive stat .edits.swp
/.edits.swp: remote path doesn't exist
```