### PR TITLE
exclude-ops for pull/push added

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,22 @@ $ drive features
 
 ## Note:
 
-MimeType inference is from the file's extension.
++ MimeType inference is from the file's extension.
 
-If you would like to coerce a certain mimeType that you'd prefer to assert with Google Drive pushes, use flag `-coerce-mime <short-key>`
+  If you would like to coerce a certain mimeType that you'd prefer to assert with Google Drive pushes, use flag `-coerce-mime <short-key>`
 
 ```shell
 $ drive push -coerce-mime docx my_test_doc
+```
+
++ Excluding certain operations can be done both for pull and push by passing in flag
+`--exclude-ops` <csv_crud_values>
+
+e.g
+
+```shell
+$ drive pull --exclude-ops "delete,update" vines
+$ drive push --exclude-ops "create" sensitive_files
 ```
 
 ### Publishing

--- a/src/commands.go
+++ b/src/commands.go
@@ -80,6 +80,7 @@ type Options struct {
 	Quiet             bool
 	StdoutIsTty       bool
 	IgnoreNameClashes bool
+	ExcludeCrudMask   CrudValue
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -62,6 +62,7 @@ const (
 	DescDelete         = "deletes the items permanently. This operation is irreversible"
 	DescDiff           = "compares local files with their remote equivalent"
 	DescEmptyTrash     = "permanently cleans out your trash"
+	DescExcludeOps     = "exclude operations"
 	DescFeatures       = "returns information about the features of your drive"
 	DescHelp           = "Get help for a topic"
 	DescInit           = "initializes a directory and authenticates user"
@@ -93,6 +94,7 @@ const (
 	CLIOptionIgnoreChecksum    = "ignore-checksum"
 	CLIOptionIgnoreConflict    = "ignore-conflict"
 	CLIOptionIgnoreNameClashes = "ignore-name-clashes"
+	CLIOptionExcludeOperations = "exclude-ops"
 )
 
 var skipChecksumNote = fmt.Sprintf(

--- a/src/misc.go
+++ b/src/misc.go
@@ -293,13 +293,24 @@ func chunkInt64(v int64) chan int {
 	return chunks
 }
 
-func NonEmptyStrings(v ...string) (splits []string) {
+func nonEmptyStrings(fn func(string) string, v ...string) (splits []string) {
 	for _, elem := range v {
+		if fn != nil {
+			elem = fn(elem)
+		}
 		if elem != "" {
 			splits = append(splits, elem)
 		}
 	}
 	return
+}
+
+func NonEmptyStrings(v ...string) (splits []string) {
+	return nonEmptyStrings(nil, v...)
+}
+
+func NonEmptyTrimmedStrings(v ...string) (splits []string) {
+	return nonEmptyStrings(strings.TrimSpace, v...)
 }
 
 var regExtStrMap = map[string]string{
@@ -362,4 +373,27 @@ var mimeTypeFromExt = _mimeTyper()
 func guessMimeType(p string) string {
 	resolvedMimeType := mimeTypeFromExt(p)
 	return resolvedMimeType
+}
+
+func CrudAtoi(ops ...string) CrudValue {
+	opValue := None
+
+	for _, op := range ops {
+		if len(op) < 1 {
+			continue
+		}
+
+		first := op[0]
+		if first == 'c' || first == 'C' {
+			opValue |= Create
+		} else if first == 'r' || first == 'R' {
+			opValue |= Read
+		} else if first == 'u' || first == 'U' {
+			opValue |= Update
+		} else if first == 'd' || first == 'D' {
+			opValue |= Delete
+		}
+	}
+
+	return opValue
 }

--- a/src/types.go
+++ b/src/types.go
@@ -35,6 +35,20 @@ const (
 	OpModConflict
 )
 
+type CrudValue int
+
+const (
+	None   CrudValue = 0
+	Create           = 1 << iota
+	Read
+	Update
+	Delete
+)
+
+var (
+	AllCrudOperations CrudValue = Create | Read | Update | Delete
+)
+
 const (
 	DifferNone    = 0
 	DifferDirType = 1 << iota
@@ -296,6 +310,20 @@ func fileDifferences(src, dest *File, ignoreChecksum bool) int {
 
 func sameFileTillChecksum(src, dest *File, ignoreChecksum bool) bool {
 	return fileDifferences(src, dest, ignoreChecksum) == DifferNone
+}
+
+func (c *Change) crudValue() CrudValue {
+	op := c.Op()
+	if op == OpAdd {
+		return Create
+	}
+	if op == OpMod || op == OpModConflict {
+		return Update
+	}
+	if op == OpDelete {
+		return Delete
+	}
+	return None
 }
 
 func (c *Change) op() Operation {


### PR DESCRIPTION
This PR is meant to address issue https://github.com/odeke-em/drive/issues/169 and adds the ability to exclude certain operations e.g say you only want create ops or create and delete

```shell
$ drive pull --exclude-ops "delete,create"
$ drive push --exclude-ops "update,delete"
```