### PR TITLE
ignore empty .driveignore

### DIFF
--- a/src/commands.go
+++ b/src/commands.go
@@ -139,6 +139,9 @@ func readCommentedFileCompileRegexp(p string) *regexp.Regexp {
 	if err != nil {
 		return nil
 	}
+	if len(clauses) < 1 {
+		return nil
+	}
 	regExComp, regErr := regexp.Compile(strings.Join(clauses, "|"))
 	if regErr != nil {
 		return nil


### PR DESCRIPTION
Dear Odeke,

thanks for continuing the development of this software! The following pull request is a solution to the problem of having an empty `.driveignore` file in the root initiated folder. When running this from a (drive) root folder:
```
rm -f .driveignore && touch .driveignore
drive pull
```
Then, the following (error) message occurs:
```
Resolving...
 | 
'/' is set to be ignored yet is being processed. Use `force` to override this
```

I assume the following:
* `readCommentedFile` in `misc.go` returns a `[]string`, which has length zero.
* `readCommentedFileCompileRegexp` in `commands.go` then joins it, separated by `|`, returning an empty, compiled string.
* `resolveToLocalFile` in `changes.go` matches the compiled expression `""` against `relToRoot` which is `"/"`

So a zero length `clauses` string array should make `readCommentedFileCompileRegexp` return `nil`, also.

Please excuse me if this is complete nonsense, in regard to my lack of experience in reading, writing, compiling (which was the hardest part) and testing `go` code.

Best,
Sven.