### PR TITLE
add .desktop ext for exportables + make executable

### DIFF
--- a/src/help.go
+++ b/src/help.go
@@ -97,6 +97,10 @@ const (
 	CLIOptionExcludeOperations = "exclude-ops"
 )
 
+const (
+	DesktopExtension = "desktop"
+)
+
 var skipChecksumNote = fmt.Sprintf(
 	"\nNote: You can skip checksum verification by passing in flag `-%s`", CLIOptionIgnoreChecksum)
 

--- a/src/misc.go
+++ b/src/misc.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 
 	spinner "github.com/odeke-em/cli-spinner"
@@ -54,6 +55,13 @@ func noopPlayable() *playable {
 		reset: noop,
 		stop:  noop,
 	}
+}
+
+func internalIgnores() (ignores []string) {
+	if runtime.GOOS == OSLinuxKey {
+		ignores = append(ignores, "\\.\\s*desktop$")
+	}
+	return ignores
 }
 
 func newPlayable(freq int64) *playable {

--- a/src/misc.go
+++ b/src/misc.go
@@ -186,7 +186,15 @@ func (f *File) serializeAsDesktopEntry(destPath string, urlMExt *urlMimeTypeExt)
 	if err != nil {
 		return 0, err
 	}
-	defer handle.Close()
+
+	defer func() {
+		handle.Close()
+		chmodErr := os.Chmod(destPath, 0755)
+		if chmodErr != nil {
+			fmt.Fprintf(os.Stderr, "%s: [desktopEntry]::chmod %v\n", destPath, chmodErr)
+		}
+	}()
+
 	icon := strings.Replace(deskEnt.icon, UnescapedPathSep, MimeTypeJoiner, -1)
 
 	return fmt.Fprintf(handle, "[Desktop Entry]\nIcon=%s\nName=%s\nType=%s\nURL=%s\n",

--- a/src/misc.go
+++ b/src/misc.go
@@ -190,8 +190,14 @@ func (f *File) serializeAsDesktopEntry(destPath string, urlMExt *urlMimeTypeExt)
 	defer func() {
 		handle.Close()
 		chmodErr := os.Chmod(destPath, 0755)
+
 		if chmodErr != nil {
 			fmt.Fprintf(os.Stderr, "%s: [desktopEntry]::chmod %v\n", destPath, chmodErr)
+		}
+
+		chTimeErr := os.Chtimes(destPath, f.ModTime, f.ModTime)
+		if chTimeErr != nil {
+			fmt.Fprintf(os.Stderr, "%s: [desktopEntry]::chtime %v\n", destPath, chTimeErr)
 		}
 	}()
 

--- a/src/pull.go
+++ b/src/pull.go
@@ -376,7 +376,7 @@ func (g *Commands) export(f *File, destAbsPath string, exports []string) (manife
 
 			// TODO: Decide if users should get to make *.desktop users even for exports
 			if runtime.GOOS == OSLinuxKey && false {
-				desktopEntryPath := sepJoin(".", exportPath, "desktop")
+				desktopEntryPath := sepJoin(".", exportPath, DesktopExtension)
 
 				_, dentErr := f.serializeAsDesktopEntry(desktopEntryPath, urlMExt)
 				if dentErr != nil {
@@ -409,7 +409,7 @@ func isLocalFile(f *File) bool {
 
 func (g *Commands) download(change *Change, exports []string) (err error) {
 	if change.Src == nil {
-		return fmt.Errorf("Tried to download nil change.Src")
+		return fmt.Errorf("tried to download nil change.Src")
 	}
 
 	destAbsPath := g.context.AbsPathOf(change.Path)
@@ -441,12 +441,12 @@ func (g *Commands) download(change *Change, exports []string) (err error) {
 
 		urlMExt := urlMimeTypeExt{
 			url:      f.AlternateLink,
-			ext:      "",
+			ext:      DesktopExtension,
 			mimeType: f.MimeType,
 		}
 
 		dirPath = filepath.Join(dirPath, f.Name)
-		desktopEntryPath := sepJoin(".", dirPath)
+		desktopEntryPath := sepJoin(".", dirPath, urlMExt.ext)
 
 		_, dentErr := f.serializeAsDesktopEntry(desktopEntryPath, &urlMExt)
 		if dentErr != nil {

--- a/src/pull.go
+++ b/src/pull.go
@@ -441,12 +441,12 @@ func (g *Commands) download(change *Change, exports []string) (err error) {
 
 		urlMExt := urlMimeTypeExt{
 			url:      f.AlternateLink,
-			ext:      DesktopExtension,
+			ext:      "",
 			mimeType: f.MimeType,
 		}
 
 		dirPath = filepath.Join(dirPath, f.Name)
-		desktopEntryPath := sepJoin(".", dirPath, urlMExt.ext)
+		desktopEntryPath := sepJoin(".", dirPath, DesktopExtension)
 
 		_, dentErr := f.serializeAsDesktopEntry(desktopEntryPath, &urlMExt)
 		if dentErr != nil {


### PR DESCRIPTION
This PR is a work in progress to address issue https://github.com/odeke-em/drive/issues/165
* Make desktop entries executable on pulling.
* Add .desktop to every pulled exportable file.

To test it out
```shell
$ go get github.com/odeke-em/drive/cmd/drive
$ cd $GOPATH/src/github.com/odeke-em/drive && git fetch --all
$ git checkout desktop-links && go get github.com/odeke-em/drive/cmd/drive
```
or read on how to apply patches here https://github.com/odeke-em/drive#applying-patches
