### PR TITLE
emptyTrash: no need to paginate + track pagination result

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -60,8 +60,9 @@ const (
 )
 
 var (
-	ErrPathNotExists = errors.New("remote path doesn't exist")
-	ErrNetLookup     = errors.New("net lookup failed")
+	ErrPathNotExists   = errors.New("remote path doesn't exist")
+	ErrNetLookup       = errors.New("net lookup failed")
+	ErrClashesDetected = fmt.Errorf("clashes detected. use `%s` to override this behavior", CLIOptionIgnoreNameClashes)
 )
 
 var (

--- a/src/trash.go
+++ b/src/trash.go
@@ -63,11 +63,12 @@ func (g *Commands) EmptyTrash() error {
 	defer spin.stop()
 
 	travSt := traversalSt{
-		depth:    -1,
-		file:     rootFile,
-		headPath: "/",
-		inTrash:  true,
-		mask:     g.opts.TypeMask,
+		depth:            -1,
+		file:             rootFile,
+		headPath:         "/",
+		inTrash:          true,
+		mask:             g.opts.TypeMask,
+		explicitNoPrompt: true,
 	}
 
 	if !g.breadthFirst(travSt, spin) {
@@ -75,7 +76,7 @@ func (g *Commands) EmptyTrash() error {
 	}
 
 	if g.opts.canPrompt() {
-		g.log.Logln("This oepration is irreversible. Empty trash! ")
+		g.log.Logln("This operation is irreversible. Empty trash! ")
 
 		if !promptForChanges() {
 			g.log.Logln("Aborted emptying trash")


### PR DESCRIPTION
This PR addresses issue #204.
What happened is that for emptyTrash, a wrong child count was being returned.