### PR TITLE
namedPipe: reject namedPipes when listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,7 @@ Background sync is not just hard, it is stupid. My technical and philosophical r
 * Probably, it doesn't work on Windows.
 * Google Drive allows a directory to contain files/directories with the same name. Client doesn't handle these cases yet. We don't recommend you to use `drive` if you have such files/directories to avoid data loss.
 * Racing conditions occur if remote is being modified while we're trying to update the file. Google Drive provides resource versioning with ETags, use Etags to avoid racy cases.
+* drive rejects reading from namedPipes because they could infinitely hang. See [issue #208](https://github.com/odeke-em/drive/issues/208).
 
 ## Reach out
 

--- a/src/changes.go
+++ b/src/changes.go
@@ -102,6 +102,12 @@ func (g *Commands) resolveToLocalFile(relToRoot, fsPath string) (local *File, er
 		err = statErr
 		return
 	}
+
+	if namedPipe(localinfo.Mode()) {
+		err = fmt.Errorf("%s (%s) is a named pipe, yet not reading from it", relToRoot, fsPath)
+		return
+	}
+
 	if localinfo != nil {
 		local = NewLocalFile(fsPath, localinfo)
 	}

--- a/src/push.go
+++ b/src/push.go
@@ -445,6 +445,14 @@ func (g *Commands) remoteMkdirAll(d string) (file *File, err error) {
 	return parent, parentErr
 }
 
+func namedPipe(mode os.FileMode) bool {
+	return (mode & os.ModeNamedPipe) != 0
+}
+
+func symlink(mode os.FileMode) bool {
+	return (mode & os.ModeSymlink) != 0
+}
+
 func list(context *config.Context, p string, hidden bool, ignore *regexp.Regexp) (fileChan chan *File, err error) {
 	absPath := context.AbsPathOf(p)
 	var f []os.FileInfo
@@ -468,10 +476,15 @@ func list(context *config.Context, p string, hidden bool, ignore *regexp.Regexp)
 				continue
 			}
 
-			symlink := (file.Mode() & os.ModeSymlink) != 0
 			resPath := gopath.Join(absPath, fileName)
 
-			if !symlink {
+			// TODO: (@odeke-em) decide on how to deal with isFifo
+			if namedPipe(file.Mode()) {
+				fmt.Fprintf(os.Stderr, "%s (%s) is a named pipe, not reading from it\n", p, resPath)
+				continue
+			}
+
+			if !symlink(file.Mode()) {
 				fileChan <- NewLocalFile(resPath, file)
 			} else {
 				var symResolvPath string

--- a/src/remote.go
+++ b/src/remote.go
@@ -515,6 +515,11 @@ func (r *Remote) copy(newName, parentId string, srcFile *File) (*File, error) {
 func (r *Remote) UpsertByComparison(args *upsertOpt) (f *File, err error) {
 	var body io.Reader
 	body, err = os.Open(args.fsAbsPath)
+	/*
+	   // TODO: (@odeke-em) decide:
+	   //   + if to reject FIFO
+	   //   + perform an assertion for fileStated.IsDir() == args.src.IsDir
+	*/
 	if args.src == nil {
 		err = fmt.Errorf("bug on: src cannot be nil")
 		return


### PR DESCRIPTION
This PR addresses issue #208 because:

Reading from a named pipe with no content will hang
infinitely until content is passed in.
Simple test here:
```shell
    $ fifoPath=testPipe
    $ mkfifo $fifoPath
    $ sleeper() { i=0;while [ $i -lt 20 ];do echo -e "sleeping $i\r"; let
    i=i+1;sleep 1;done; echo "done here $i" >> $fifoPath; }
    $ sleeper & # Put it in the background
    $ cat $fifoPath # Going to hang for the 20 seconds -- this can happen
    infinitely
```