### PR TITLE
avoid nil dereferences for http.Get() + serialize

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -447,3 +447,7 @@ func CrudAtoi(ops ...string) CrudValue {
 
 	return opValue
 }
+
+func httpOk(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}

--- a/src/pull.go
+++ b/src/pull.go
@@ -319,14 +319,14 @@ func (g *Commands) localMod(wg *sync.WaitGroup, change *Change, exports []string
 
 func (g *Commands) localAdd(wg *sync.WaitGroup, change *Change, exports []string) (err error) {
 	defer func() {
-		if err == nil {
-			src := change.Src
-			index := src.ToIndex()
-			sErr := g.context.SerializeIndex(index, g.context.AbsPathOf(""))
+		if err == nil && change.Src != nil {
+			fileToSerialize := change.Src
+			index := fileToSerialize.ToIndex()
+			indexErr := g.context.SerializeIndex(index, g.context.AbsPathOf(""))
 
 			// TODO: Should indexing errors be reported?
-			if sErr != nil {
-				g.log.LogErrf("serializeIndex %s: %v\n", src.Name, sErr)
+			if indexErr != nil {
+				g.log.LogErrf("serializeIndex %s: %v\n", fileToSerialize.Name, indexErr)
 			}
 		}
 		wg.Done()


### PR DESCRIPTION
This PR addresses issue #217 where http.Get returns a nil response on err yet the response was always dereferenced without check. The issue was identified, and investigated + basically solved by @sselph who unfortunately couldn't make a PR asap till over the week. This PR is representative of @sselph's tracking. It also handles the case in a file doesn't exist remotely and is forced to be pulled locally.