### PR TITLE
help: allow for variants of -h, --help

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -25,10 +25,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/odeke-em/command"
 	"github.com/odeke-em/drive/config"
 	"github.com/odeke-em/drive/gen"
 	"github.com/odeke-em/drive/src"
-	"github.com/rakyll/command"
 )
 
 var context *config.Context
@@ -75,6 +75,8 @@ func main() {
 	bindCommandWithAliases(drive.DeleteKey, drive.DescDelete, &deleteCmd{}, []string{})
 	bindCommandWithAliases(drive.UnpubKey, drive.DescUnpublish, &unpublishCmd{}, []string{})
 	bindCommandWithAliases(drive.VersionKey, drive.Version, &versionCmd{}, []string{})
+
+	command.DefineHelp(&helpCmd{})
 	command.ParseAndRun()
 }
 
@@ -87,12 +89,7 @@ func (cmd *helpCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 }
 
 func (cmd *helpCmd) Run(args []string) {
-	arg := drive.AllKey
-	if len(args) >= 1 {
-		arg = args[0]
-	}
-
-	drive.ShowDescription(arg)
+	drive.ShowDescriptions(args...)
 	exitWithError(nil)
 }
 

--- a/src/help.go
+++ b/src/help.go
@@ -210,6 +210,17 @@ func ShowAllDescriptions() {
 	}
 }
 
+func ShowDescriptions(topics ...string) {
+	if len(topics) < 1 {
+		topics = append(topics, AllKey)
+	}
+
+	for _, topic := range topics {
+		ShowDescription(topic)
+		fmt.Println()
+	}
+}
+
 func ShowDescription(topic string) {
 	if topic == AllKey {
 		ShowAllDescriptions()


### PR DESCRIPTION
* Fixes #45 by setting a custom usage function
* Also allows for multiple topics to be selected
on `drive --help/help/-h [topics...]
Involved patching the flag parser lib externally.

#### Originally:
```shell
$ drive --help
Usage of drive:
$
$ drive -h
Usage of drive:
```

#### Now:
```shell
$ drive -h push
Name
	push - push local changes to Google Drive
Description
	Uploads content to your Google Drive from your local path
	Push comes in a couple of flavors
		* Ordinary push: `drive push path1 path2 path3`
		* Mounted push: `drive push -m path1 [path2 path3] drive_context_path`
	
Note: You can skip checksum verification by passing in flag `-ignore-checksum`

* For usage flags: `drive push -h`
$
$ drive --help pull push
Name
	pull - pulls remote changes from Google Drive
Description
	Downloads content from the remote drive or modifies
	 local content to match that on your Google Drive
	
Note: You can skip checksum verification by passing in flag `-ignore-checksum`

* For usage flags: `drive pull -h`


Name
	push - push local changes to Google Drive
Description
	Uploads content to your Google Drive from your local path
	Push comes in a couple of flavors
		* Ordinary push: `drive push path1 path2 path3`
		* Mounted push: `drive push -m path1 [path2 path3] drive_context_path`
	
Note: You can skip checksum verification by passing in flag `-ignore-checksum`

* For usage flags: `drive push -h`

```