### PR TITLE
sort implemented!

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,14 @@ $ drive list -owners -l -version
 $ drive list -depth 3 --id 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 0fM9rt0Yc9kJRPSTFNk9kSTVvb0U
 ```
 
++ Listing allows for sorting by fields e.g `name`, `version`, `size, `modtime`, lastModifiedByMeTime `lvt`, `md5`. To do this in reverse order, suffix `_r` or `-` to the selected key
+
+e.g to first sort by modTime, then largest-to-smallest and finally most number of saves:
+
+```
+$ drive list --sort modtime,size_r,version_r Photos
+```
+
 ### Stating Files
 
 The `stat` commands show detailed file information for example people with whom it is shared, their roles and accountTypes, and

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -157,6 +157,7 @@ type listCmd struct {
 	matches     *bool
 	owners      *bool
 	quiet       *bool
+	sort        *string
 }
 
 func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -172,6 +173,7 @@ func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.noPrompt = fs.Bool(drive.NoPromptKey, false, "shows no prompt before pagination")
 	cmd.owners = fs.Bool("owners", false, "shows the owner names per file")
 	cmd.recursive = fs.Bool("r", false, "recursively list subdirectories")
+	cmd.sort = fs.String(drive.SortKey, "", drive.DescSort)
 	cmd.matches = fs.Bool(drive.MatchesKey, false, "list by prefix")
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.byId = fs.Bool(drive.CLIOptionId, false, "list by id instead of path")
@@ -210,6 +212,10 @@ func (cmd *listCmd) Run(args []string) {
 		depth = drive.InfiniteDepth
 	}
 
+	meta := map[string][]string{
+		drive.SortKey: drive.NonEmptyTrimmedStrings(*cmd.sort),
+	}
+
 	options := drive.Options{
 		Depth:     depth,
 		Hidden:    *cmd.hidden,
@@ -221,6 +227,7 @@ func (cmd *listCmd) Run(args []string) {
 		Sources:   sources,
 		TypeMask:  typeMask,
 		Quiet:     *cmd.quiet,
+		Meta:      &meta,
 	}
 
 	if *cmd.shared {

--- a/src/help.go
+++ b/src/help.go
@@ -46,18 +46,26 @@ const (
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
 
-	CoercedMimeKeyKey = "coerced-mime"
-	DepthKey          = "depth"
-	ForceKey          = "force"
-	QuietKey          = "quiet"
-	QuitShortKey      = "q"
-	YesShortKey       = "Y"
-	QuitLongKey       = "quit"
-	MatchesKey        = "matches"
-	HiddenKey         = "hidden"
-	NoPromptKey       = "no-prompt"
-	TrashedKey        = "trashed"
-	DriveRepoRelPath  = "github.com/odeke-em/drive"
+	CoercedMimeKeyKey     = "coerced-mime"
+	DepthKey              = "depth"
+	ForceKey              = "force"
+	QuietKey              = "quiet"
+	QuitShortKey          = "q"
+	YesShortKey           = "Y"
+	QuitLongKey           = "quit"
+	MatchesKey            = "matches"
+	HiddenKey             = "hidden"
+	Md5Key                = "md5"
+	NoPromptKey           = "no-prompt"
+	SizeKey               = "size"
+	NameKey               = "name"
+	OriginalNameKey       = "oname"
+	ModTimeKey            = "modt"
+	LastViewedByMeTimeKey = "lvt"
+	TypeKey               = "type"
+	TrashedKey            = "trashed"
+	SortKey               = "sort"
+	DriveRepoRelPath      = "github.com/odeke-em/drive"
 )
 
 const (
@@ -93,6 +101,7 @@ const (
 		"\n\t* Are on a low power device"
 	DescIgnoreConflict    = "turns off the conflict resolution safety"
 	DescIgnoreNameClashes = "ignore name clashes"
+	DescSort              = "sort items in the order\n\t* md5.\n\t* name.\n\t* size.\n\t* type.\n\t* version"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -461,3 +461,20 @@ func CrudAtoi(ops ...string) CrudValue {
 func httpOk(statusCode int) bool {
 	return statusCode >= 200 && statusCode <= 299
 }
+
+func hasAnyPrefix(value string, prefixes ...string) bool {
+	return _hasAnyAtExtreme(value, strings.HasPrefix, prefixes)
+}
+
+func hasAnySuffix(value string, prefixes ...string) bool {
+	return _hasAnyAtExtreme(value, strings.HasSuffix, prefixes)
+}
+
+func _hasAnyAtExtreme(value string, fn func(string, string) bool, queries []string) bool {
+	for _, query := range queries {
+		if fn(value, query) {
+			return true
+		}
+	}
+	return false
+}

--- a/src/sort.go
+++ b/src/sort.go
@@ -1,0 +1,236 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"sort"
+	"strings"
+)
+
+const (
+	AttrUnknown = iota
+	AttrSize
+	AttrModTime
+	AttrLastViewedByMeTime
+	AttrVersion
+	AttrIsDir
+	AttrMd5Checksum
+	AttrMimeType
+	AttrName
+)
+
+type attr int
+
+type fileList []*File
+type lastViewedTimeFlist fileList
+type md5Flist fileList
+type mimeTypeFlist fileList
+type modTimeFlist fileList
+type nameFlist fileList
+type sizeFlist fileList
+type typeFlist fileList
+type versionFlist fileList
+
+var (
+	lastViewedTimeCmpLess = _lessCmper(AttrLastViewedByMeTime)
+	md5CmpLess            = _lessCmper(AttrMd5Checksum)
+	mimeTypeCmpLess       = _lessCmper(AttrMimeType)
+	modTimeCmpLess        = _lessCmper(AttrModTime)
+	nameCmpLess           = _lessCmper(AttrName)
+	sizeCmpLess           = _lessCmper(AttrSize)
+	versionCmpLess        = _lessCmper(AttrVersion)
+	typeCmpLess           = _lessCmper(AttrIsDir)
+)
+
+func (fl modTimeFlist) Less(i, j int) bool {
+	return modTimeCmpLess(fl[i], fl[j])
+}
+
+func (fl modTimeFlist) Len() int {
+	return len(fl)
+}
+
+func (fl modTimeFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl typeFlist) Less(i, j int) bool {
+	return typeCmpLess(fl[i], fl[j])
+}
+
+func (fl typeFlist) Len() int {
+	return len(fl)
+}
+
+func (fl typeFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl mimeTypeFlist) Less(i, j int) bool {
+	return mimeTypeCmpLess(fl[i], fl[j])
+}
+
+func (fl mimeTypeFlist) Len() int {
+	return len(fl)
+}
+
+func (fl mimeTypeFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl lastViewedTimeFlist) Less(i, j int) bool {
+	return lastViewedTimeCmpLess(fl[i], fl[j])
+}
+
+func (fl lastViewedTimeFlist) Len() int {
+	return len(fl)
+}
+
+func (fl lastViewedTimeFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl versionFlist) Less(i, j int) bool {
+	return versionCmpLess(fl[i], fl[j])
+}
+
+func (fl versionFlist) Len() int {
+	return len(fl)
+}
+
+func (fl versionFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl nameFlist) Less(i, j int) bool {
+	return nameCmpLess(fl[i], fl[j])
+}
+
+func (fl nameFlist) Len() int {
+	return len(fl)
+}
+
+func (fl nameFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl md5Flist) Less(i, j int) bool {
+	return md5CmpLess(fl[i], fl[j])
+}
+
+func (fl md5Flist) Len() int {
+	return len(fl)
+}
+
+func (fl md5Flist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func (fl sizeFlist) Less(i, j int) bool {
+	return sizeCmpLess(fl[i], fl[j])
+}
+
+func (fl sizeFlist) Len() int {
+	return len(fl)
+}
+
+func (fl sizeFlist) Swap(i, j int) {
+	fl[i], fl[j] = fl[j], fl[i]
+}
+
+func attrAtoiSorter(a string, fl []*File) (attr, sort.Interface, bool) {
+	aLower := strings.ToLower(a)
+	if len(aLower) < 1 {
+		return AttrUnknown, nil, false
+	}
+
+	reverse := hasAnySuffix(aLower, "_r", "-")
+
+	if hasAnyPrefix(aLower, Md5Key) {
+		return AttrMd5Checksum, md5Flist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, NameKey) {
+		return AttrName, nameFlist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, SizeKey) {
+		return AttrSize, sizeFlist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, TypeKey) {
+		return AttrIsDir, typeFlist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, ModTimeKey) {
+		return AttrModTime, modTimeFlist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, LastViewedByMeTimeKey) {
+		return AttrLastViewedByMeTime, lastViewedTimeFlist(fl), reverse
+	}
+	if hasAnyPrefix(aLower, VersionKey) {
+		return AttrVersion, versionFlist(fl), reverse
+	}
+
+	return AttrUnknown, nil, false
+}
+
+func nilCmpOrProceed(fallback func(*File, *File) bool) func(*File, *File) bool {
+	return func(l, r *File) bool {
+		if l == nil {
+			return false
+		}
+		if r == nil {
+			return true
+		}
+		return fallback(l, r)
+	}
+}
+
+func _lessCmper(_attr attr) func(*File, *File) bool {
+	switch _attr {
+	case AttrSize:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.Size < r.Size })
+	case AttrVersion:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.Version < r.Version })
+	case AttrIsDir:
+		return nilCmpOrProceed(func(l, r *File) bool { return !l.IsDir })
+	case AttrMd5Checksum:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.Md5Checksum < r.Md5Checksum })
+	case AttrName:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.Name < r.Name })
+	case AttrModTime:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.ModTime.Before(r.ModTime) })
+	case AttrLastViewedByMeTime:
+		return nilCmpOrProceed(func(l, r *File) bool { return l.LastViewedByMeTime.Before(r.LastViewedByMeTime) })
+	}
+
+	return nilCmpOrProceed(func(l, r *File) bool { return true })
+}
+
+func (g *Commands) sort(fl []*File, attrStrValues ...string) []*File {
+	for _, attrStr := range attrStrValues {
+		attrEnum, sortInterface, reverse := attrAtoiSorter(attrStr, fl)
+
+		if attrEnum == AttrUnknown {
+			g.log.LogErrf("%s is an unknown sort attribute\n", attrStr)
+			continue
+		}
+
+		if reverse {
+			sortInterface = sort.Reverse(sortInterface)
+		} else {
+			sort.Sort(sortInterface)
+		}
+	}
+
+	return fl
+}


### PR DESCRIPTION
This PR implements sorting and addresses issue https://github.com/odeke-em/drive/issues/40.

It implements multi field sorting as well as reverse order sorting e.g

* To first sort by modTime, then largest-to-smallest and finally most number of saves:

```
$ drive list --sort modtime,size_r,version_r Photos
```
OR
```
$ drive list --sort modtime,size-,version- Photos
```
OR the same command but in reverse
```
$ drive list --sort modtime_r,size,version Photos
```