### PR TITLE
Add -md5sum option to "stat"

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@
   - [Unpublishing](#unpublishing)
   - [Sharing and Emailing](#sharing-and-emailing)
   - [Unsharing](#unsharing)
-  - [Touching](#touch)
+  - [Touching](#touching)
   - [Trashing and Untrashing](#trashing-and-untrashing)
   - [Emptying the Trash](#emptying-the-trash)
   - [Deleting](#deleting)
   - [Listing Files](#listing-files)
   - [Stating Files](#stating-files)
+  - [Retrieving md5 checksums](#retrieving-md5-checksums)
   - [Quota](#quota)
   - [Features](#features)
   - [About](#about)
@@ -507,6 +508,35 @@ OR
 $ drive stat -depth 4 --id 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 0fM9rt0Yc9kJRPSTFNk9kSTVvb0U
 ```
 
+### Retrieving md5 Checksums
+
+The `md5sum` command quickly retrieves the md5 checksums of the files on your drive. The result can be fed into the "md5sum -c" shell command to validate the integrity of the files on Drive versus the local copies.
+
+Check that files on Drive are present and match local files:
+
+```shell
+~/MyDrive/folder$ drive md5sum | md5sum -c
+```
+
+Do a two-way diff (will also locate files missing on either side)
+
+```shell
+~/MyDrive/folder$ diff <(drive md5sum) <(md5sum *)
+```
+
+Same as above, but include subfolders 
+
+```shell
+~/MyDrive/folder$ diff <(drive md5sum -r) <(find * -type f | sort | xargs md5sum)
+```
+
+Compare across two different Drive accounts, including subfolders
+
+```shell
+~$ diff <(drive md5sum -r MyDrive/folder) <(drive md5sum -r OtherDrive/otherfolder)
+```
+
+_Note: Running the 'drive md5sum' command retrieves pre-computed md5 sums from Drive; its speed is proportional to the number of files on Drive. Running the shell 'md5sum' command on local files requires reading through the files; its speed is proportional to the size of the files._
 
 ### Quota
 

--- a/drive-gen/Godeps/Godeps.json
+++ b/drive-gen/Godeps/Godeps.json
@@ -55,6 +55,26 @@
 			"Rev": "ec6d5d770f531108a6464462b2201b74fcd09314"
 		},
 		{
+			"ImportPath": "golang.org/x/text/collate",
+			"Rev": "df923bbb63f8ea3a26bb743e2a497abd0ab585f7"
+		},
+		{
+			"ImportPath": "golang.org/x/text/internal/colltab",
+			"Rev": "df923bbb63f8ea3a26bb743e2a497abd0ab585f7"
+		},
+		{
+			"ImportPath": "golang.org/x/text/language",
+			"Rev": "df923bbb63f8ea3a26bb743e2a497abd0ab585f7"
+		},
+		{
+			"ImportPath": "golang.org/x/text/transform",
+			"Rev": "df923bbb63f8ea3a26bb743e2a497abd0ab585f7"
+		},
+		{
+			"ImportPath": "golang.org/x/text/unicode/norm",
+			"Rev": "df923bbb63f8ea3a26bb743e2a497abd0ab585f7"
+		},
+		{
 			"ImportPath": "google.golang.org/api/googleapi/internal/uritemplates",
 			"Rev": "caddaef3288600132bb9c9ea3f638e565d74cd54"
 		},

--- a/src/commands.go
+++ b/src/commands.go
@@ -81,6 +81,7 @@ type Options struct {
 	StdoutIsTty       bool
 	IgnoreNameClashes bool
 	ExcludeCrudMask   CrudValue
+	Md5sum            bool
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -45,6 +45,7 @@ const (
 	UntrashKey    = "untrash"
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
+	Md5sumKey     = "md5sum"
 
 	CoercedMimeKeyKey     = "coerced-mime"
 	DepthKey              = "depth"
@@ -94,6 +95,7 @@ const (
 	DescUntrash        = "restores files from trash to their original locations"
 	DescUnpublish      = "revokes public access to a file"
 	DescVersion        = "prints the version"
+	DescMd5sum         = "prints a list compatible with md5sum(1)"
 	DescAccountTypes   = "\n\t* anyone.\n\t* user.\n\t* domain.\n\t* group"
 	DescRoles          = "\n\t* owner.\n\t* reader.\n\t* writer.\n\t* commenter."
 	DescIgnoreChecksum = "avoids computation of checksums as a final check." +


### PR DESCRIPTION
This branch implements a `drive stat -md5sum` option, and the equivalent `drive md5sum` command

Instructions for use in README.md

Please see issues #115 and #225 

Please note use of golang.org/x/text in stat.go

Cheers,

m