### PR TITLE
Improved search for listing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: go
-go: 1.2
+go: 1.4

--- a/README.md
+++ b/README.md
@@ -495,6 +495,14 @@ e.g to first sort by modTime, then largest-to-smallest and finally most number o
 $ drive list --sort modtime,size_r,version_r Photos
 ```
 
+* For advanced listing
+
+```shell
+$ drive list --skip-mime mp4,doc,txt
+$ drive list --match-mime xls,docx
+$ drive list --exact-title url_test,Photos
+```
+
 ### Stating Files
 
 The `stat` commands show detailed file information for example people with whom it is shared, their roles and accountTypes, and

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -142,24 +142,29 @@ func (cmd *quotaCmd) Run(args []string) {
 }
 
 type listCmd struct {
-	byId        *bool
-	hidden      *bool
-	pageCount   *int
-	recursive   *bool
-	files       *bool
-	directories *bool
-	depth       *int
-	pageSize    *int64
-	longFmt     *bool
-	noPrompt    *bool
-	shared      *bool
-	inTrash     *bool
-	version     *bool
-	matches     *bool
-	owners      *bool
-	quiet       *bool
-	skipMimeKey *string
-	sort        *string
+	byId         *bool
+	hidden       *bool
+	pageCount    *int
+	recursive    *bool
+	files        *bool
+	directories  *bool
+	depth        *int
+	pageSize     *int64
+	longFmt      *bool
+	noPrompt     *bool
+	shared       *bool
+	inTrash      *bool
+	version      *bool
+	matches      *bool
+	owners       *bool
+	quiet        *bool
+	skipMimeKey  *string
+	matchMimeKey *string
+	exactTitle   *string
+	matchOwner   *string
+	exactOwner   *string
+	notOwner     *string
+	sort         *string
 }
 
 func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -179,6 +184,11 @@ func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.matches = fs.Bool(drive.MatchesKey, false, "list by prefix")
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
+	cmd.matchMimeKey = fs.String(drive.CLIOptionMatchMime, "", drive.DescMatchMime)
+	cmd.exactTitle = fs.String(drive.CLIOptionExactTitle, "", drive.DescExactTitle)
+	cmd.matchOwner = fs.String(drive.CLIOptionMatchOwner, "", drive.DescMatchOwner)
+	cmd.exactOwner = fs.String(drive.CLIOptionExactOwner, "", drive.DescExactOwner)
+	cmd.notOwner = fs.String(drive.CLIOptionNotOwner, "", drive.DescNotOwner)
 	cmd.byId = fs.Bool(drive.CLIOptionId, false, "list by id instead of path")
 
 	return fs
@@ -216,8 +226,13 @@ func (cmd *listCmd) Run(args []string) {
 	}
 
 	meta := map[string][]string{
-		drive.SortKey:        drive.NonEmptyTrimmedStrings(*cmd.sort),
-		drive.SkipMimeKeyKey: drive.NonEmptyTrimmedStrings(strings.Split(*cmd.skipMimeKey, ",")...),
+		drive.SortKey:         drive.NonEmptyTrimmedStrings(*cmd.sort),
+		drive.SkipMimeKeyKey:  drive.NonEmptyTrimmedStrings(strings.Split(*cmd.skipMimeKey, ",")...),
+		drive.MatchMimeKeyKey: drive.NonEmptyTrimmedStrings(strings.Split(*cmd.matchMimeKey, ",")...),
+		drive.ExactTitleKey:   drive.NonEmptyTrimmedStrings(strings.Split(*cmd.exactTitle, ",")...),
+		drive.MatchOwnerKey:   drive.NonEmptyTrimmedStrings(strings.Split(*cmd.matchOwner, ",")...),
+		drive.ExactOwnerKey:   drive.NonEmptyTrimmedStrings(strings.Split(*cmd.exactOwner, ",")...),
+		drive.NotOwnerKey:     drive.NonEmptyTrimmedStrings(strings.Split(*cmd.notOwner, ",")...),
 	}
 
 	options := drive.Options{
@@ -366,6 +381,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.excludeOps = fs.String(drive.CLIOptionExcludeOperations, "", drive.DescExcludeOps)
 	cmd.byId = fs.Bool(drive.CLIOptionId, false, "pull by id instead of path")
+	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
 	cmd.explicitlyExport = fs.Bool(drive.CLIOptionExplicitlyExport, false, drive.DescExplicitylPullExports)
 
 	return fs

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -342,6 +342,7 @@ type pullCmd struct {
 	piped             *bool
 	quiet             *bool
 	ignoreNameClashes *bool
+	skipMimeKey       *string
 	explicitlyExport  *bool
 }
 
@@ -376,6 +377,10 @@ func (cmd *pullCmd) Run(args []string) {
 		exitWithError(fmt.Errorf("all CRUD operations forbidden"))
 	}
 
+	meta := map[string][]string{
+		drive.SkipMimeKeyKey: drive.NonEmptyTrimmedStrings(strings.Split(*cmd.skipMimeKey, ",")...),
+	}
+
 	// Filter out empty strings.
 	exports := drive.NonEmptyTrimmedStrings(strings.Split(*cmd.export, ",")...)
 
@@ -396,6 +401,7 @@ func (cmd *pullCmd) Run(args []string) {
 		IgnoreNameClashes: *cmd.ignoreNameClashes,
 		ExcludeCrudMask:   excludeCrudMask,
 		ExplicitlyExport:  *cmd.explicitlyExport,
+		Meta:              &meta,
 	}
 
 	if *cmd.matches {
@@ -427,6 +433,7 @@ type pushCmd struct {
 	quiet             *bool
 	coercedMimeKey    *string
 	excludeOps        *string
+	skipMimeKey       *string
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -512,6 +519,7 @@ func (cmd *pushCmd) createPushOptions() *drive.Options {
 
 	meta := map[string][]string{
 		drive.CoercedMimeKeyKey: drive.NonEmptyTrimmedStrings(*cmd.coercedMimeKey),
+		drive.SkipMimeKeyKey:    drive.NonEmptyTrimmedStrings(strings.Split(*cmd.skipMimeKey, ",")...),
 	}
 
 	excludes := drive.NonEmptyTrimmedStrings(strings.Split(*cmd.excludeOps, ",")...)

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -158,6 +158,7 @@ type listCmd struct {
 	matches     *bool
 	owners      *bool
 	quiet       *bool
+	skipMimeKey *string
 	sort        *string
 }
 
@@ -177,6 +178,7 @@ func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.sort = fs.String(drive.SortKey, "", drive.DescSort)
 	cmd.matches = fs.Bool(drive.MatchesKey, false, "list by prefix")
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
+	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
 	cmd.byId = fs.Bool(drive.CLIOptionId, false, "list by id instead of path")
 
 	return fs
@@ -214,7 +216,8 @@ func (cmd *listCmd) Run(args []string) {
 	}
 
 	meta := map[string][]string{
-		drive.SortKey: drive.NonEmptyTrimmedStrings(*cmd.sort),
+		drive.SortKey:        drive.NonEmptyTrimmedStrings(*cmd.sort),
+		drive.SkipMimeKeyKey: drive.NonEmptyTrimmedStrings(strings.Split(*cmd.skipMimeKey, ",")...),
 	}
 
 	options := drive.Options{
@@ -452,6 +455,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.coercedMimeKey = fs.String(drive.CoercedMimeKeyKey, "", "the mimeType you are trying to coerce this file to be")
 	cmd.ignoreNameClashes = fs.Bool(drive.CLIOptionIgnoreNameClashes, false, drive.DescIgnoreNameClashes)
 	cmd.excludeOps = fs.String(drive.CLIOptionExcludeOperations, "", drive.DescExcludeOps)
+	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
 	return fs
 }
 

--- a/src/help.go
+++ b/src/help.go
@@ -69,6 +69,11 @@ const (
 	TypeKey               = "type"
 	TrashedKey            = "trashed"
 	SkipMimeKeyKey        = "skip-mime"
+	MatchMimeKeyKey       = "exact-mime"
+	ExactTitleKey         = "exact-title"
+	MatchOwnerKey         = "match-owner"
+	ExactOwnerKey         = "exact-owner"
+	NotOwnerKey           = "skip-owner"
 	SortKey               = "sort"
 	DriveRepoRelPath      = "github.com/odeke-em/drive"
 )
@@ -110,6 +115,12 @@ const (
 	DescIgnoreNameClashes = "ignore name clashes"
 	DescSort              = "sort items in the order\n\t* md5.\n\t* name.\n\t* size.\n\t* type.\n\t* version"
 	DescSkipMime          = "skip elements with mimeTypes derived from these extensison"
+	DescMatchMime         = "get elements with the exact mimeTypes derived from extensisons"
+	DescMatchTitle        = "elements with matching titles"
+	DescExactTitle        = "get elements with the exact titles"
+	DescMatchOwner        = "elements with matching owners"
+	DescExactOwner        = "elements with the exact owner"
+	DescNotOwner          = "ignore elements owned by these users"
 )
 
 const (
@@ -122,6 +133,12 @@ const (
 	CLIOptionNoClobber         = "no-clobber"
 	CLIOptionNotify            = "notify"
 	CLIOptionSkipMime          = "skip-mime"
+	CLIOptionMatchMime         = "exact-mime"
+	CLIOptionExactTitle        = "exact-title"
+	CLIOptionMatchTitle        = "match-mime"
+	CLIOptionExactOwner        = "exact-owner"
+	CLIOptionMatchOwner        = "match-owner"
+	CLIOptionNotOwner          = "skip-owner"
 )
 
 const (

--- a/src/help.go
+++ b/src/help.go
@@ -109,6 +109,7 @@ const (
 	DescIgnoreConflict    = "turns off the conflict resolution safety"
 	DescIgnoreNameClashes = "ignore name clashes"
 	DescSort              = "sort items in the order\n\t* md5.\n\t* name.\n\t* size.\n\t* type.\n\t* version"
+	DescSkipMime          = "skip elements with mimeTypes derived from these extensison"
 )
 
 const (

--- a/src/help.go
+++ b/src/help.go
@@ -68,6 +68,7 @@ const (
 	RoleKey               = "role"
 	TypeKey               = "type"
 	TrashedKey            = "trashed"
+	SkipMimeKeyKey        = "skip-mime"
 	SortKey               = "sort"
 	DriveRepoRelPath      = "github.com/odeke-em/drive"
 )
@@ -119,6 +120,7 @@ const (
 	CLIOptionId                = "id"
 	CLIOptionNoClobber         = "no-clobber"
 	CLIOptionNotify            = "notify"
+	CLIOptionSkipMime          = "skip-mime"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -360,6 +360,7 @@ var regExtStrMap = map[string]string{
 	"csv":   "text/csv",
 	"html?": "text/html",
 	"te?xt": "text/plain",
+	"xml":   "text/xml",
 
 	"gif":   "image/gif",
 	"png":   "image/png",
@@ -385,6 +386,8 @@ var regExtStrMap = map[string]string{
 
 	"apk": "application/vnd.android.package-archive",
 	"bin": "application/octet-stream",
+
+	"mp3": "audio/mpeg",
 
 	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 	"pptx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.presentation",
@@ -430,7 +433,11 @@ func cacher(regMap map[*regexp.Regexp]string) func(string) string {
 	}
 }
 
-var mimeTypeFromQuery = cacher(regMapper(regExtStrMap, map[string]string{"folder": DriveFolderMimeType}))
+var mimeTypeFromQuery = cacher(regMapper(regExtStrMap, map[string]string{
+	"folder": DriveFolderMimeType,
+	"mp4":    "video/mp4",
+}))
+
 var mimeTypeFromExt = cacher(regMapper(regExtStrMap))
 
 func guessMimeType(p string) string {

--- a/src/pull.go
+++ b/src/pull.go
@@ -81,7 +81,14 @@ func (g *Commands) Pull(byId bool) (err error) {
 
 func (g *Commands) PullMatches() (err error) {
 	var cl []*Change
-	matches, err := g.rem.FindMatches(g.opts.Path, g.opts.Sources, false)
+	mq := matchQuery{
+		dirPath: g.opts.Path,
+		inTrash: false,
+		titleSearches: []fuzzyStringsValuePair{
+			{fuzzyLevel: Like, values: g.opts.Sources},
+		},
+	}
+	matches, err := g.rem.FindMatches(&mq) // g.opts.Path, g.opts.Sources, false)
 
 	if err != nil {
 		return err

--- a/src/touch.go
+++ b/src/touch.go
@@ -60,7 +60,15 @@ func (g *Commands) Touch(byId bool) (err error) {
 }
 
 func (g *Commands) TouchByMatch() (err error) {
-	matches, err := g.rem.FindMatches(g.opts.Path, g.opts.Sources, false)
+	mq := matchQuery{
+		dirPath: g.opts.Path,
+		inTrash: false,
+		titleSearches: []fuzzyStringsValuePair{
+			{fuzzyLevel: Like, values: g.opts.Sources, inTrash: false},
+		},
+	}
+
+	matches, err := g.rem.FindMatches(&mq)
 	if err != nil {
 		return err
 	}

--- a/src/trash.go
+++ b/src/trash.go
@@ -127,7 +127,15 @@ func (g *Commands) trasher(relToRoot string, opt *trashOpt) (*Change, error) {
 }
 
 func (g *Commands) trashByMatch(inTrash, permanent bool) error {
-	matches, err := g.rem.FindMatches(g.opts.Path, g.opts.Sources, inTrash)
+	mq := matchQuery{
+		dirPath: g.opts.Path,
+		inTrash: false,
+		titleSearches: []fuzzyStringsValuePair{
+			{fuzzyLevel: Like, values: g.opts.Sources, inTrash: inTrash},
+		},
+	}
+
+	matches, err := g.rem.FindMatches(&mq)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses issue #242.
Added extra search options for list e.g:
```shell
$ drive list --skip-mime mp4,doc,txt
$ drive list --match-mime xls,docx
$ drive list --exact-title url_test,Photos
```

This sets the ground work for other search options to be added in the future.