### PR TITLE
clashes: properly detecting clashes & warnings

### DIFF
--- a/src/diff.go
+++ b/src/diff.go
@@ -35,7 +35,9 @@ func (g *Commands) Diff() (err error) {
 
 	for _, relToRootPath := range g.opts.Sources {
 		fsPath := g.context.AbsPathOf(relToRootPath)
-		ccl, cErr := g.changeListResolve(relToRootPath, fsPath, true)
+		ccl, _, cErr := g.changeListResolve(relToRootPath, fsPath, true)
+		// TODO: Show the conflicts if any
+
 		if cErr != nil {
 			return cErr
 		}

--- a/src/push.go
+++ b/src/push.go
@@ -53,9 +53,11 @@ func (g *Commands) Push() (err error) {
 		os.Exit(1)
 	}()
 
+	// TODO: Look at clashes?
+
 	for _, relToRootPath := range g.opts.Sources {
 		fsPath := g.context.AbsPathOf(relToRootPath)
-		ccl, cErr := g.changeListResolve(relToRootPath, fsPath, true)
+		ccl, _, cErr := g.changeListResolve(relToRootPath, fsPath, true)
 		if cErr != nil {
 			spin.stop()
 			return cErr
@@ -68,7 +70,7 @@ func (g *Commands) Push() (err error) {
 	mount := g.opts.Mount
 	if mount != nil {
 		for _, mt := range mount.Points {
-			ccl, cerr := lonePush(g, root, mt.Name, mt.MountPath)
+			ccl, _, cerr := lonePush(g, root, mt.Name, mt.MountPath)
 			if cerr == nil {
 				cl = append(cl, ccl...)
 			}
@@ -260,7 +262,7 @@ func (g *Commands) playPushChanges(cl []*Change, opMap *map[Operation]sizeCounte
 	return err
 }
 
-func lonePush(g *Commands, parent, absPath, path string) (cl []*Change, err error) {
+func lonePush(g *Commands, parent, absPath, path string) (cl, clashes []*Change, err error) {
 	r, err := g.rem.FindByPath(absPath)
 	if err != nil && err != ErrPathNotExists {
 		return


### PR DESCRIPTION
This PR addresses issues https://github.com/odeke-em/drive/issues/222 and duplicate https://github.com/odeke-em/drive/issues/241
* Properly detects clashes as far as can be traversed and
also warning the user if any exist or aborting.
