### PR TITLE
New file or folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
   - [Listing Files](#listing-files)
   - [Stating Files](#stating-files)
   - [Retrieving md5 checksums](#retrieving-md5-checksums)
+  - [New File](#new-file)
   - [Quota](#quota)
   - [Features](#features)
   - [About](#about)
@@ -559,6 +560,19 @@ Compare across two different Drive accounts, including subfolders
 ```
 
 _Note: Running the 'drive md5sum' command retrieves pre-computed md5 sums from Drive; its speed is proportional to the number of files on Drive. Running the shell 'md5sum' command on local files requires reading through the files; its speed is proportional to the size of the files._
+
+
+### New File
+
+drive allows you to create an empty file or folder remotely
+Sample usage:
+
+```shell
+$ drive new --folder flux
+$ drive new --mime-key doc bofx
+$ drive new --mime-key folder content
+$ drive new flux.txt oxen.pdf # Allow auto type resolution from the extension
+```
 
 ### Quota
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -781,6 +781,29 @@ func (cmd *trashCmd) Run(args []string) {
 	}
 }
 
+type newCmd struct {
+	folder *bool
+}
+
+func (cmd *newCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.folder = fs.Bool("folder", false, "create a folder if set otherwise create a regular file")
+	return fs
+}
+
+func (cmd *newCmd) Run(args []string) {
+	sources, context, path := preprocessArgs(args)
+	opts := drive.Options{
+		Path:    path,
+		Sources: sources,
+	}
+
+	if *cmd.folder {
+		exitWithError(drive.New(context, &opts).NewFolder())
+	} else {
+		exitWithError(drive.New(context, &opts).NewFolder())
+	}
+}
+
 type copyCmd struct {
 	quiet     *bool
 	recursive *bool

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -76,6 +76,7 @@ func main() {
 	bindCommandWithAliases(drive.DeleteKey, drive.DescDelete, &deleteCmd{}, []string{})
 	bindCommandWithAliases(drive.UnpubKey, drive.DescUnpublish, &unpublishCmd{}, []string{})
 	bindCommandWithAliases(drive.VersionKey, drive.Version, &versionCmd{}, []string{})
+	bindCommandWithAliases(drive.NewKey, drive.DescNew, &newCmd{}, []string{})
 
 	command.DefineHelp(&helpCmd{})
 	command.ParseAndRun()
@@ -782,11 +783,13 @@ func (cmd *trashCmd) Run(args []string) {
 }
 
 type newCmd struct {
-	folder *bool
+	folder  *bool
+	mimeKey *string
 }
 
 func (cmd *newCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.folder = fs.Bool("folder", false, "create a folder if set otherwise create a regular file")
+	cmd.mimeKey = fs.String(drive.MimeKey, "", "coerce the file to this mimeType")
 	return fs
 }
 
@@ -797,10 +800,16 @@ func (cmd *newCmd) Run(args []string) {
 		Sources: sources,
 	}
 
+	meta := map[string][]string{
+		drive.MimeKey: drive.NonEmptyTrimmedStrings(strings.Split(*cmd.mimeKey, ",")...),
+	}
+
+	opts.Meta = &meta
+
 	if *cmd.folder {
 		exitWithError(drive.New(context, &opts).NewFolder())
 	} else {
-		exitWithError(drive.New(context, &opts).NewFolder())
+		exitWithError(drive.New(context, &opts).NewFile())
 	}
 }
 

--- a/src/help.go
+++ b/src/help.go
@@ -46,6 +46,7 @@ const (
 	UnpubKey      = "unpub"
 	VersionKey    = "version"
 	Md5sumKey     = "md5sum"
+	NewKey        = "new"
 
 	CoercedMimeKeyKey     = "coerced-mime"
 	DepthKey              = "depth"
@@ -75,6 +76,8 @@ const (
 	ExactOwnerKey         = "exact-owner"
 	NotOwnerKey           = "skip-owner"
 	SortKey               = "sort"
+	FolderKey             = "folder"
+	MimeKey               = "mime-key"
 	DriveRepoRelPath      = "github.com/odeke-em/drive"
 )
 
@@ -121,6 +124,7 @@ const (
 	DescMatchOwner        = "elements with matching owners"
 	DescExactOwner        = "elements with the exact owner"
 	DescNotOwner          = "ignore elements owned by these users"
+	DescNew               = "create a new file/folder"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -442,6 +442,9 @@ func cacher(regMap map[*regexp.Regexp]string) func(string) string {
 var mimeTypeFromQuery = cacher(regMapper(regExtStrMap, map[string]string{
 	"folder": DriveFolderMimeType,
 	"mp4":    "video/mp4",
+	"docs":   "application/vnd.google-apps.document",
+	"sheet":  "application/vnd.google-apps.sheet",
+	"form":   "application/vnd.google-apps.form",
 }))
 
 var mimeTypeFromExt = cacher(regMapper(regExtStrMap))

--- a/src/new.go
+++ b/src/new.go
@@ -1,0 +1,23 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+func (g *Commands) NewFolder() (err error) {
+	return err
+}
+
+func (g *Commands) NewFile() (err error) {
+	return err
+}

--- a/src/remote.go
+++ b/src/remote.go
@@ -445,6 +445,10 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 		uploaded.MimeType = DriveFolderMimeType
 	}
 
+	if args.src.MimeType != "" {
+		uploaded.MimeType = args.src.MimeType
+	}
+
 	if args.mimeKey != "" {
 		uploaded.MimeType = guessMimeType(args.mimeKey)
 	}


### PR DESCRIPTION
This PR addresses issue #245.
It allows for creation of new file or folders e.g
```shell
$ drive new --folder flux
$ drive new --mime-key doc bofx
$ drive new --mime-key folder content
$ drive new flux.txt oxen.pdf # Allow auto type resolution from the extension
```