### PR TITLE
Reverse order sort not working

### DIFF
--- a/src/sort.go
+++ b/src/sort.go
@@ -236,10 +236,9 @@ func (g *Commands) sort(fl []*File, attrStrValues ...string) []*File {
 
 		if reverse {
 			sortInterface = sort.Reverse(sortInterface)
-		} else {
-			// Stable is needed if more than one sort keyword is used
-			sort.Stable(sortInterface)
 		}
+		// Stable is needed if more than one sort keyword is used
+		sort.Stable(sortInterface)
 	}
 
 	return fl


### PR DESCRIPTION
Tiny bug - sorting in reverse order not working. 

Before this fix:

````
michael@taygetos:~/GoogleDrive/test2$ drive ls -l -sort size-
-- owner       6.00B     	0B7L9Xx9YIQk9ODJfV2EwMG16RDA		2015-06-26 11:26:26 +0000 UTC	/test2/file4                                      
-- owner       45.00B    	0B7L9Xx9YIQk9M2t2WU1McEd6QlE		2015-06-26 11:25:39 +0000 UTC	/test2/file1                                      
-- owner       31.00B    	0B7L9Xx9YIQk9V2pjRnlIOV82c1k		2015-06-26 11:23:09 +0000 UTC	/test2/file3                                      
-- owner       13.00B    	0B7L9Xx9YIQk9dW4zSWphcHhJM0k		2015-06-26 11:23:02 +0000 UTC	/test2/file2                                      
````

After this fix:

````
michael@taygetos:~/GoogleDrive/test2$ drive ls -l -sort size-
-- owner       45.00B    	0B7L9Xx9YIQk9M2t2WU1McEd6QlE		2015-06-26 11:25:39 +0000 UTC	/test2/file1                                      
-- owner       31.00B    	0B7L9Xx9YIQk9V2pjRnlIOV82c1k		2015-06-26 11:23:09 +0000 UTC	/test2/file3                                      
-- owner       13.00B    	0B7L9Xx9YIQk9dW4zSWphcHhJM0k		2015-06-26 11:23:02 +0000 UTC	/test2/file2                                      
-- owner       6.00B     	0B7L9Xx9YIQk9ODJfV2EwMG16RDA		2015-06-26 11:26:26 +0000 UTC	/test2/file4   
````

Cheers,

Michael