### PR TITLE
push: acknowledge mkdirAll errors + bug fix

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -306,6 +306,7 @@ func (g *Commands) remoteMod(change *Change) (err error) {
 	}
 
 	absPath := g.context.AbsPathOf(change.Path)
+
 	var parent *File
 	if change.Dest != nil && change.Src != nil {
 		change.Src.Id = change.Dest.Id // TODO: bad hack
@@ -315,7 +316,14 @@ func (g *Commands) remoteMod(change *Change) (err error) {
 	parent, err = g.remoteMkdirAll(parentPath)
 
 	if err != nil {
+		g.log.LogErrf("remoteMod/remoteMkdirAll: `%s` got %v\n", parentPath, err)
 		return err
+	}
+
+	if parent == nil {
+		err = errCannotMkdirAll(parentPath)
+		g.log.LogErrln(err)
+		return
 	}
 
 	args := upsertOpt{
@@ -411,7 +419,12 @@ func (g *Commands) remoteDelete(change *Change) error {
 func (g *Commands) remoteMkdirAll(d string) (file *File, err error) {
 	// Try the lookup one last time in case a coroutine raced us to it.
 	retrFile, retryErr := g.rem.FindByPath(d)
-	if retryErr == nil && retrFile != nil {
+
+	if retryErr != nil && retryErr != ErrPathNotExists {
+		return retrFile, retryErr
+	}
+
+	if retrFile != nil {
 		return retrFile, nil
 	}
 
@@ -440,16 +453,23 @@ func (g *Commands) remoteMkdirAll(d string) (file *File, err error) {
 		src:      remoteFile,
 	}
 	parent, parentErr = g.rem.UpsertByComparison(&args)
-	if parentErr == nil && parent != nil {
-		index := parent.ToIndex()
-		wErr := g.context.SerializeIndex(index, g.context.AbsPathOf(""))
-
-		// TODO: Should indexing errors be reported?
-		if wErr != nil {
-			g.log.LogErrf("serializeIndex %s: %v\n", parent.Name, wErr)
-		}
+	if parentErr != nil {
+		return parent, parentErr
 	}
-	return parent, parentErr
+
+	if parent == nil {
+		return parent, ErrPathNotExists
+	}
+
+	index := parent.ToIndex()
+	wErr := g.context.SerializeIndex(index, g.context.AbsPathOf(""))
+
+	// TODO: Should indexing errors be reported?
+	if wErr != nil {
+		g.log.LogErrf("serializeIndex %s: %v\n", parent.Name, wErr)
+	}
+
+	return parent, nil
 }
 
 func namedPipe(mode os.FileMode) bool {

--- a/src/remote.go
+++ b/src/remote.go
@@ -60,15 +60,20 @@ const (
 )
 
 var (
-	ErrPathNotExists   = errors.New("remote path doesn't exist")
-	ErrNetLookup       = errors.New("net lookup failed")
-	ErrClashesDetected = fmt.Errorf("clashes detected. use `%s` to override this behavior", CLIOptionIgnoreNameClashes)
+	ErrPathNotExists                  = errors.New("remote path doesn't exist")
+	ErrNetLookup                      = errors.New("net lookup failed")
+	ErrClashesDetected                = fmt.Errorf("clashes detected. use `%s` to override this behavior", CLIOptionIgnoreNameClashes)
+	ErrGoogleApiInvalidQueryHardCoded = errors.New("googleapi: Error 400: Invalid query, invalid")
 )
 
 var (
 	UnescapedPathSep = fmt.Sprintf("%c", os.PathSeparator)
 	EscapedPathSep   = url.QueryEscape(UnescapedPathSep)
 )
+
+func errCannotMkdirAll(p string) error {
+	return fmt.Errorf("cannot mkdirAll: `%s`", p)
+}
 
 type Remote struct {
 	client       *http.Client
@@ -659,6 +664,9 @@ func (r *Remote) findByPathRecvRaw(parentId string, p []string, trashed bool) (f
 	files, err := req.Do()
 
 	if err != nil {
+		if err.Error() == ErrGoogleApiInvalidQueryHardCoded.Error() { // Send the user back the query information
+			err = fmt.Errorf("err: %v query: `%s`", err, expr)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR addresses some issues found out in #250 in particular:
* Acknowledge errors encountered during mkdirAll or push and abort since mostly
not yet looking at retryable errors.
* Fixed up order of checking for retryFile in mkdirAll
instead of checking if err != ErrPathNotExists yet err
could be nil. This is fatal because in combination with ignored errors,
it inaccurately reports that a folder doesn't exist.