### PR TITLE
ignore-check: use fullPath vs only basename

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -439,6 +439,19 @@ func cacher(regMap map[*regexp.Regexp]string) func(string) string {
 	}
 }
 
+func anyMatch(pat *regexp.Regexp, args ...string) bool {
+	if pat == nil {
+		return false
+	}
+
+	for _, arg := range args {
+		if pat.Match([]byte(arg)) {
+			return true
+		}
+	}
+	return false
+}
+
 var mimeTypeFromQuery = cacher(regMapper(regExtStrMap, map[string]string{
 	"folder": DriveFolderMimeType,
 	"mp4":    "video/mp4",

--- a/src/push.go
+++ b/src/push.go
@@ -505,14 +505,14 @@ func list(context *config.Context, p string, hidden bool, ignore *regexp.Regexp)
 			if fileName == config.GDDirSuffix {
 				continue
 			}
-			if ignore != nil && ignore.Match([]byte(fileName)) {
-				continue
-			}
 			if isHidden(fileName, hidden) {
 				continue
 			}
 
 			resPath := gopath.Join(absPath, fileName)
+			if anyMatch(ignore, fileName, resPath) {
+				continue
+			}
 
 			// TODO: (@odeke-em) decide on how to deal with isFifo
 			if namedPipe(file.Mode()) {
@@ -526,6 +526,10 @@ func list(context *config.Context, p string, hidden bool, ignore *regexp.Regexp)
 				var symResolvPath string
 				symResolvPath, err = filepath.EvalSymlinks(resPath)
 				if err != nil {
+					continue
+				}
+
+				if anyMatch(ignore, symResolvPath) {
 					continue
 				}
 


### PR DESCRIPTION
This PR addresses issue https://github.com/odeke-em/drive/issues/270

ignore pattern checks should operate on full resolved
paths instead of only the basename of paths. This applies
to resolved paths for symlinks as well.