### PR TITLE
index-handling and move error fixes

### DIFF
--- a/src/move.go
+++ b/src/move.go
@@ -90,7 +90,8 @@ func (g *Commands) move(opt *moveOpt) (err error) {
 
 		// TODO: If oldParent is not found, retry since it may have been moved temporarily at least
 		if oldParent != nil && oldParent.Id == newParent.Id {
-			return nil
+			return fmt.Errorf("src and dest are the same srcParentId %s destParentId %s",
+				customQuote(oldParent.Id), customQuote(newParent.Id))
 		}
 	}
 
@@ -105,7 +106,7 @@ func (g *Commands) move(opt *moveOpt) (err error) {
 
 	if dupCheck != nil {
 		if dupCheck.Id == remSrc.Id { // Trying to move to self
-			return nil
+			return fmt.Errorf("move: trying to move fileId:%s to self fileId:%s", customQuote(dupCheck.Id), customQuote(remSrc.Id))
 		}
 		if !g.opts.Force {
 			return fmt.Errorf("%s already exists. Use `%s` flag to override this behaviour", newFullPath, ForceKey)

--- a/src/pull.go
+++ b/src/pull.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/odeke-em/drive/config"
 	"github.com/odeke-em/statos"
 )
 
@@ -248,6 +249,7 @@ func (g *Commands) pullByPath() (cl, clashes []*Change, err error) {
 	for _, relToRootPath := range g.opts.Sources {
 		fsPath := g.context.AbsPathOf(relToRootPath)
 		ccl, cclashes, cErr := g.changeListResolve(relToRootPath, fsPath, false)
+		fmt.Println(ccl, cclashes, cErr, relToRootPath, fsPath)
 		if cErr != nil {
 			if cErr != ErrClashesDetected {
 				return cl, clashes, cErr
@@ -373,7 +375,7 @@ func (g *Commands) localMod(wg *sync.WaitGroup, change *Change, exports []string
 			indexErr := g.createIndex(src)
 			// TODO: Should indexing errors be reported?
 			if indexErr != nil {
-				g.log.LogErrf("serializeIndex %s: %v\n", src.Name, indexErr)
+				g.log.LogErrf("localMod:createIndex %s: %v\n", src.Name, indexErr)
 			}
 		}
 		wg.Done()
@@ -415,7 +417,7 @@ func (g *Commands) localAdd(wg *sync.WaitGroup, change *Change, exports []string
 			indexErr := g.createIndex(fileToSerialize)
 			// TODO: Should indexing errors be reported?
 			if indexErr != nil {
-				g.log.LogErrf("serializeIndex %s: %v\n", fileToSerialize.Name, indexErr)
+				g.log.LogErrf("localAdd:createIndex %s: %v\n", fileToSerialize.Name, indexErr)
 			}
 		}
 		wg.Done()
@@ -457,7 +459,8 @@ func (g *Commands) localDelete(wg *sync.WaitGroup, change *Change) (err error) {
 			dest := change.Dest
 			index := dest.ToIndex()
 			rmErr := g.context.RemoveIndex(index, g.context.AbsPathOf(""))
-			if rmErr != nil {
+			// For the sake of files missing remotely yet present locally and might not have a FileId
+			if rmErr != nil && rmErr != config.ErrEmptyFileIdForIndex {
 				g.log.LogErrf("localDelete removing index for: \"%s\" at \"%s\" %v\n", dest.Name, dest.BlobAt, rmErr)
 			}
 		}


### PR DESCRIPTION
This PR addresses issue #275 and in particular it does:
* Handle cases when files are missing remotely but present
locally, in this case the FileId is always empty.
* Provide error message when a move's src == dest.