### PR TITLE
provide different binary name for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ Otherwise:
 $ go get github.com/odeke-em/drive/drive-gen && drive-gen
 ```
 
+In case you need a specific binary e.g for Debian folks [issue #271](https://github.com/odeke-em/drive/issues/271) and [issue 277](https://github.com/odeke-em/drive/issues/277)
+
+```shell
+$ go get -u github.com/odeke-em/drive/google-drive
+```
+
+That should produce a binary `google-drive`
+
+OR
+
+To bundle debug information with the binary, you can run:
+
+```shell
+$ go get -u github.com/odeke-em/drive/drive/drive-gen && drive-gen google-drive
+```
+
+
 ### Godep
 
 + Using godep

--- a/drive-gen/build.go
+++ b/drive-gen/build.go
@@ -26,6 +26,8 @@ import (
 	"github.com/odeke-em/xon/pkger/src"
 )
 
+var AliasBinaryDir = "google-drive"
+
 func logErr(err error) {
 	fmt.Fprintf(os.Stderr, "%v\n", err)
 }
@@ -98,7 +100,18 @@ func main() {
 	goBinaryPath, lookUpErr := exec.LookPath("go")
 	exitIfError(lookUpErr)
 
-	driveMainPath := filepath.Join(drive.DriveRepoRelPath, "cmd", "drive")
+	argc := len(os.Args)
+
+	srcDirSegments := []string{"cmd", "drive"}
+
+	if argc >= 2 {
+		if os.Args[1] == AliasBinaryDir {
+			srcDirSegments = []string{AliasBinaryDir}
+		}
+	}
+
+	allCombined := append([]string{drive.DriveRepoRelPath}, srcDirSegments...)
+	driveMainPath := filepath.Join(allCombined...)
 	generateCmd := exec.Cmd{
 		Args:   []string{goBinaryPath, "get", driveMainPath},
 		Dir:    ".",

--- a/gen/generated.go
+++ b/gen/generated.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-// This file was auto-generated at 2015-04-15 01:38:47.768 -0600 MDT
+// This file was auto-generated at 2015-07-10 02:15:09.751 -0600 MDT
 // Edits will be overwritten!
 
 
@@ -22,7 +22,7 @@ package generated
 import "github.com/odeke-em/xon/pkger/src"
 
 var PkgInfo = &pkger.PkgInfo {
-	CommitHash: "<CURRENT_COMMIT>",
-	GoVersion: "<GO_VERSION>",
-	OsInfo: "<OS_INFO>",
+	CommitHash: "'e4941e8c8347eb7c71d858a31a0a6d09d6ccdcda'",
+	GoVersion: "go1.4.2",
+	OsInfo: "darwin/amd64",
 }

--- a/google-drive/main.go
+++ b/google-drive/main.go
@@ -1,0 +1,1 @@
+../cmd/drive/main.go


### PR DESCRIPTION
This PR addresses issues #271 and #277 
This allows for folks that might need different binary names to
have them. For example:
    `go get -u github.com/odeke-em/drive/google-drive`
    OR
    `
    go get -u github.com/odeke-em/drive/drive-gen &&
    drive-gen google-drive
    `