### PR TITLE
deinit command + info added

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Configuration](#configuration)
 - [Usage](#usage)
   - [Initializing](#initializing)
+  - [De Initializing](#de-initializing)
   - [Pulling](#pulling)
     - [Exporting Docs](#exporting-docs)
   - [Pushing](#pushing)
@@ -132,6 +133,17 @@ Before you can use `drive`, you need to mount your Google Drive directory on you
 $ drive init ~/gdrive
 $ cd ~/gdrive
 ```
+
+### De Initializing
+
+The opposite of `drive init`, it will remove your credentials locally as well as configuration associated files.
+
+```shell
+$ drive deinit [--no-prompt]
+```
+
+For a complete de-initializing don't forget to revoke account access, [please see revoking account access](#revoking-account-access)
+
 
 ### Pulling
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -57,6 +57,7 @@ func main() {
 	bindCommandWithAliases(drive.EmptyTrashKey, drive.DescEmptyTrash, &emptyTrashCmd{}, []string{})
 	bindCommandWithAliases(drive.FeaturesKey, drive.DescFeatures, &featuresCmd{}, []string{})
 	bindCommandWithAliases(drive.InitKey, drive.DescInit, &initCmd{}, []string{})
+	bindCommandWithAliases(drive.DeInitKey, drive.DescDeInit, &deInitCmd{}, []string{})
 	bindCommandWithAliases(drive.HelpKey, drive.DescHelp, &helpCmd{}, []string{})
 
 	bindCommandWithAliases(drive.ListKey, drive.DescList, &listCmd{}, []string{})
@@ -128,6 +129,25 @@ func (cmd *initCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *initCmd) Run(args []string) {
 	exitWithError(drive.New(initContext(args), nil).Init())
+}
+
+type deInitCmd struct {
+	noPrompt *bool
+}
+
+func (cmd *deInitCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.noPrompt = fs.Bool(drive.NoPromptKey, false, "disables the prompt")
+	return fs
+}
+
+func (cmd *deInitCmd) Run(args []string) {
+	_, context, path := preprocessArgsByToggle(args, true)
+	opts := &drive.Options{
+		NoPrompt: *cmd.noPrompt,
+		Path:     path,
+	}
+
+	exitWithError(drive.New(context, opts).DeInit())
 }
 
 type quotaCmd struct{}

--- a/src/help.go
+++ b/src/help.go
@@ -28,6 +28,7 @@ const (
 	FeaturesKey   = "features"
 	HelpKey       = "help"
 	InitKey       = "init"
+	DeInitKey     = "deinit"
 	LinkKey       = "Link"
 	ListKey       = "list"
 	MoveKey       = "move"
@@ -95,6 +96,7 @@ const (
 	DescIndex                 = "fetch indices from remote"
 	DescHelp                  = "Get help for a topic"
 	DescInit                  = "initializes a directory and authenticates user"
+	DescDeInit                = "removes the user's credentials and initialized files"
 	DescList                  = "lists the contents of remote path"
 	DescMove                  = "move files/folders"
 	DescQuota                 = "prints out information related to your quota space"
@@ -150,6 +152,11 @@ const (
 	CLIOptionNotOwner           = "skip-owner"
 	CLIOptionPruneIndices       = "prune"
 	CLIOptionAllIndexOperations = "all-ops"
+)
+
+const (
+	GoogleApiClientIdEnvKey     = "GOOGLE_API_CLIENT_ID"
+	GoogleApiClientSecretEnvKey = "GOOGLE_API_CLIENT_SECRET"
 )
 
 const (

--- a/src/init.go
+++ b/src/init.go
@@ -21,8 +21,8 @@ import (
 )
 
 func (g *Commands) Init() error {
-	g.context.ClientId = os.Getenv("GOOGLE_API_CLIENT_ID")
-	g.context.ClientSecret = os.Getenv("GOOGLE_API_CLIENT_SECRET")
+	g.context.ClientId = os.Getenv(GoogleApiClientIdEnvKey)
+	g.context.ClientSecret = os.Getenv(GoogleApiClientSecretEnvKey)
 	if g.context.ClientId == "" || g.context.ClientSecret == "" {
 		g.context.ClientId = "354790962074-7rrlnuanmamgg1i4feed12dpuq871bvd.apps.googleusercontent.com"
 		g.context.ClientSecret = "RHjKdah8RrHFwu6fcc0uEVCw"
@@ -36,4 +36,16 @@ func (g *Commands) Init() error {
 
 	g.context.RefreshToken = refreshToken
 	return g.context.Write()
+}
+
+func (g *Commands) DeInit() error {
+	prompt := func(args ...interface{}) bool {
+		if !g.opts.canPrompt() {
+			return true
+		}
+
+		return promptForChanges(args...)
+	}
+
+	return g.context.DeInitialize(prompt, true)
 }


### PR DESCRIPTION
This PR addresses issue #282 by adding `deinit` functionality.

```shell
$ drive deinit
```
OR

```shell
$ drive deinit --no-prompt
```

Paired with the sections on uninstalling and revoking account access, this should give the user total control of their account.