### PR TITLE
fix mimeType for sheet + add other mimes

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -453,11 +453,13 @@ func anyMatch(pat *regexp.Regexp, args ...string) bool {
 }
 
 var mimeTypeFromQuery = cacher(regMapper(regExtStrMap, map[string]string{
-	"folder": DriveFolderMimeType,
-	"mp4":    "video/mp4",
-	"docs":   "application/vnd.google-apps.document",
-	"sheet":  "application/vnd.google-apps.sheet",
-	"form":   "application/vnd.google-apps.form",
+	"docs":         "application/vnd.google-apps.document",
+	"folder":       DriveFolderMimeType,
+	"form":         "application/vnd.google-apps.form",
+	"mp4":          "video/mp4",
+	"presentation": "application/vnd.google-apps.presentation",
+	"sheet":        "application/vnd.google-apps.spreadsheet",
+	"script":       "application/vnd.google-apps.script",
 }))
 
 var mimeTypeFromExt = cacher(regMapper(regExtStrMap))


### PR DESCRIPTION
This PR addresses issue #289. In particular
+ Fixes the mimeType for sheet to .spreadsheet from .sheet.
+ Also adds in mimeTypes for Google presentations + scripts.

### Before
```shell
$ cd ~/your_drive
$ drive new --mime-key sheet tables
/tables: googleapi: Error 400: Invalid mime type provided, invalid
```
### After
```shell
$ cd ~/your_drive
$ drive new --mime-key sheet tables
/tables ML5VWnlKvLf71GYdBjIMG96lxCpjMBFNPISHKF3Uy4X2
$ drive list -l tables
 0.00B         ML5VWnlKvLf71GYdBjIMG96lxCpjMBFNPISHKF3Uy4X2 	2015-07-19 03:58:18 +0000 UTC	/tables 
```