### PR TITLE
os centric aliases per file

### DIFF
--- a/src/types.go
+++ b/src/types.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -182,6 +183,27 @@ func fauxLocalFile(relToRootPath string) *File {
 		Name:    relToRootPath,
 		Size:    0,
 	}
+}
+
+func (f *File) localAliases(prefix string) (aliases []string) {
+	aliases = append(aliases, prefix)
+
+	if f == nil {
+		return
+	}
+
+	suffixes := []string{}
+
+	if runtime.GOOS == OSLinuxKey && hasExportLinks(f) {
+		suffixes = append(suffixes, DesktopExtension)
+	}
+
+	for _, suffix := range suffixes {
+		join := sepJoin(".", prefix, suffix)
+		aliases = append(aliases, join)
+	}
+
+	return
 }
 
 type Change struct {


### PR DESCRIPTION
This PR addresses issue #292.

Since os specific export files are created, allow for inclusion of
these aliases e.g Google Docs on Linux get exported to *.desktop,
*.desktop files should be recognized too