### PR TITLE
about: provide all subset commands if no subcmd set

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -741,6 +741,11 @@ func (cmd *aboutCmd) Run(args []string) {
 	if *cmd.filesize {
 		mask |= drive.AboutFileSizes
 	}
+
+	if mask == drive.AboutNone { // No option set
+		mask = drive.AboutQuota | drive.AboutFeatures | drive.AboutFileSizes
+	}
+
 	exitWithError(drive.New(context, &drive.Options{
 		Quiet: *cmd.quiet,
 	}).About(mask))


### PR DESCRIPTION
This PR addresses issue #294 by ensuring that if `drive about` is invoked with no sub set commands it prints out all information otherwise a user would have to read the manual, yet this is isn't necessary.