### PR TITLE
exports: fix regression for exports

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -29,8 +29,8 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
-	"github.com/odeke-em/drive/config"
 	drive "github.com/google/google-api-go-client/drive/v2"
+	"github.com/odeke-em/drive/config"
 	"github.com/odeke-em/statos"
 )
 

--- a/src/types.go
+++ b/src/types.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/odeke-em/drive/config"
 	drive "github.com/google/google-api-go-client/drive/v2"
+	"github.com/odeke-em/drive/config"
 )
 
 type Operation int


### PR DESCRIPTION
This PR fixes exporting. It was broken by commit https://github.com/odeke-em/drive/commit/787e7f03bdba2ec00cc9da558ca8a47781a7b975 in PR https://github.com/odeke-em/drive/pull/307
In particular this PR:
+ Fixed up exporting of Google Docs + Sheets.
+ Ensures that an ignored 'os.Mkdir' error is not thrown. Could have
used os.MkdirAll but then want to track the lack of parents locally.