### PR TITLE
Remove per-operation `Open()`/`Close()` calls to BoltDB

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -410,6 +410,8 @@ func (cmd *indexCmd) Run(args []string) {
 	byId := *cmd.byId
 	byMatches := *cmd.matches
 	sources, context, path := preprocessArgsByToggle(args, byMatches || byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	options := &drive.Options{
 		Sources:           sources,
@@ -493,6 +495,8 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *pullCmd) Run(args []string) {
 	sources, context, path := preprocessArgsByToggle(args, (*cmd.byId || *cmd.matches))
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	excludes := drive.NonEmptyTrimmedStrings(strings.Split(*cmd.excludeOps, ",")...)
 	excludeCrudMask := drive.CrudAtoi(excludes...)
@@ -584,6 +588,8 @@ func (cmd *pushCmd) Run(args []string) {
 		cmd.pushMounted(args)
 	} else {
 		sources, context, path := preprocessArgs(args)
+		exitWithError(context.OpenDB())
+		defer context.CloseDB()
 
 		options := cmd.createPushOptions()
 		options.Path = path
@@ -616,6 +622,8 @@ func (cmd *touchCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *touchCmd) Run(args []string) {
 	sources, context, path := preprocessArgsByToggle(args, *cmd.matches || *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	opts := drive.Options{
 		Hidden:    *cmd.hidden,
@@ -692,6 +700,9 @@ func (cmd *pushCmd) pushMounted(args []string) {
 
 	rest = drive.NonEmptyStrings(rest...)
 	context, path := discoverContext(contextArgs)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	contextAbsPath, err := filepath.Abs(path)
 	exitWithError(err)
 
@@ -770,6 +781,9 @@ func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *diffCmd) Run(args []string) {
 	sources, context, path := preprocessArgs(args)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	exitWithError(drive.New(context, &drive.Options{
 		Recursive:         true,
 		Path:              path,
@@ -846,6 +860,8 @@ func (cmd *deleteCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *deleteCmd) Run(args []string) {
 	sources, context, path := preprocessArgsByToggle(args, *cmd.matches || *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	opts := drive.Options{
 		Path:    path,
@@ -877,6 +893,9 @@ func (cmd *trashCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *trashCmd) Run(args []string) {
 	sources, context, path := preprocessArgsByToggle(args, *cmd.matches || *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	opts := drive.Options{
 		Path:    path,
 		Sources: sources,
@@ -903,6 +922,9 @@ func (cmd *newCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *newCmd) Run(args []string) {
 	sources, context, path := preprocessArgs(args)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	opts := drive.Options{
 		Path:    path,
 		Sources: sources,
@@ -947,6 +969,9 @@ func (cmd *copyCmd) Run(args []string) {
 	dest := args[end]
 
 	sources, context, path := preprocessArgsByToggle(args, *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	// Unshift by the end path
 	sources = sources[:len(sources)-1]
 	destRels, err := relativePaths(context.AbsPathOf(""), dest)
@@ -980,6 +1005,8 @@ func (cmd *untrashCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 func (cmd *untrashCmd) Run(args []string) {
 	sources, context, path := preprocessArgsByToggle(args, *cmd.byId || *cmd.matches)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	opts := drive.Options{
 		Path:    path,
@@ -1058,6 +1085,9 @@ func (cmd *moveCmd) Run(args []string) {
 		exitWithError(fmt.Errorf("move: expecting a path or more"))
 	}
 	sources, context, path := preprocessArgsByToggle(args, *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
+
 	// Unshift by the end path
 	sources = sources[:len(sources)-1]
 
@@ -1094,6 +1124,8 @@ func (cmd *renameCmd) Run(args []string) {
 	}
 	rest, last := args[:argc-1], args[argc-1]
 	sources, context, path := preprocessArgsByToggle(rest, *cmd.byId)
+	exitWithError(context.OpenDB())
+	defer context.CloseDB()
 
 	sources = append(sources, last)
 	exitWithError(drive.New(context, &drive.Options{


### PR DESCRIPTION
* `Context` now maintains a DB handle that is kept alive