### PR TITLE
Easier parallel uploads caching

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1051,7 +1051,7 @@ type moveCmd struct {
 
 func (cmd *moveCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
-	cmd.byId = fs.Bool(drive.CLIOptionId, false, "unshare by id instead of path")
+	cmd.byId = fs.Bool(drive.CLIOptionId, false, "move by id instead of path")
 	return fs
 }
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -557,6 +557,7 @@ type pushCmd struct {
 	coercedMimeKey    *string
 	excludeOps        *string
 	skipMimeKey       *string
+	verbose           *bool
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -576,6 +577,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.ignoreNameClashes = fs.Bool(drive.CLIOptionIgnoreNameClashes, false, drive.DescIgnoreNameClashes)
 	cmd.excludeOps = fs.String(drive.CLIOptionExcludeOperations, "", drive.DescExcludeOps)
 	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
+	cmd.verbose = fs.Bool(drive.CLIOptionVerboseShortKey, false, drive.DescVerbose)
 	return fs
 }
 
@@ -666,6 +668,7 @@ func (cmd *pushCmd) createPushOptions() *drive.Options {
 		TypeMask:          mask,
 		ExcludeCrudMask:   excludeCrudMask,
 		IgnoreNameClashes: *cmd.ignoreNameClashes,
+		Verbose:           *cmd.verbose,
 	}
 }
 

--- a/src/changes.go
+++ b/src/changes.go
@@ -212,6 +212,9 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 
 	var change *Change
 
+	cl = make([]*Change, 0)
+	clashes = make([]*Change, 0)
+
 	explicitlyRequested := g.opts.ExplicitlyExport && hasExportLinks(r) && len(g.opts.Exports) >= 1
 
 	if clr.push {

--- a/src/commands.go
+++ b/src/commands.go
@@ -84,6 +84,7 @@ type Options struct {
 	ExplicitlyExport  bool
 	Md5sum            bool
 	indexingOnly      bool
+	Verbose           bool
 }
 
 type Commands struct {

--- a/src/commands.go
+++ b/src/commands.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cheggaaa/pb"
 	"github.com/mattn/go-isatty"
+	expirable "github.com/odeke-em/cache"
 	"github.com/odeke-em/drive/config"
 	"github.com/odeke-em/log"
 )
@@ -93,7 +94,8 @@ type Commands struct {
 	opts    *Options
 	log     *log.Logger
 
-	progress *pb.ProgressBar
+	progress      *pb.ProgressBar
+	mkdirAllCache *expirable.OperationCache
 }
 
 func (opts *Options) canPrompt() bool {
@@ -139,10 +141,11 @@ func New(context *config.Context, opts *Options) *Commands {
 	}
 
 	return &Commands{
-		context: context,
-		rem:     r,
-		opts:    opts,
-		log:     logger,
+		context:       context,
+		rem:           r,
+		opts:          opts,
+		log:           logger,
+		mkdirAllCache: expirable.New(),
 	}
 }
 

--- a/src/help.go
+++ b/src/help.go
@@ -132,6 +132,7 @@ const (
 	DescNotOwner           = "ignore elements owned by these users"
 	DescNew                = "create a new file/folder"
 	DescAllIndexOperations = "perform all the index related operations"
+	DescVerbose            = "show step by step information verbosely"
 )
 
 const (
@@ -152,6 +153,8 @@ const (
 	CLIOptionNotOwner           = "skip-owner"
 	CLIOptionPruneIndices       = "prune"
 	CLIOptionAllIndexOperations = "all-ops"
+	CLIOptionVerboseKey         = "verbose"
+	CLIOptionVerboseShortKey    = "v"
 )
 
 const (

--- a/src/help.go
+++ b/src/help.go
@@ -157,6 +157,7 @@ const (
 const (
 	GoogleApiClientIdEnvKey     = "GOOGLE_API_CLIENT_ID"
 	GoogleApiClientSecretEnvKey = "GOOGLE_API_CLIENT_SECRET"
+	GoMaxProcsKey               = "GOMAXPROCS"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -36,7 +36,7 @@ const (
 )
 
 const (
-	DefaultMaxProcs = 5
+	DefaultMaxProcs = 4
 )
 
 var BytesPerKB = float64(1024)
@@ -546,4 +546,36 @@ func maxProcs() int {
 
 func customQuote(s string) string {
 	return "\"" + strings.Replace(strings.Replace(s, "\\", "\\\\", -1), "\"", "\\\"", -1) + "\""
+}
+
+type expirableCacheValue struct {
+	value     interface{}
+	entryTime time.Time
+}
+
+func (e *expirableCacheValue) Expired(q time.Time) bool {
+	if e == nil {
+		return true
+	}
+
+	return e.entryTime.Before(q)
+}
+
+func (e *expirableCacheValue) Value() interface{} {
+	if e == nil {
+		return nil
+	}
+
+	return e.value
+}
+
+func newExpirableCacheValueWithOffset(v interface{}, offset time.Duration) *expirableCacheValue {
+	return &expirableCacheValue{
+		value:     v,
+		entryTime: time.Now().Add(offset),
+	}
+}
+
+var newExpirableCacheValue = func(v interface{}) *expirableCacheValue {
+	return newExpirableCacheValueWithOffset(v, 10*time.Minute)
 }

--- a/src/misc.go
+++ b/src/misc.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,10 @@ const (
 	RemoteDriveRootPath = "My Drive"
 
 	FmtTimeString = "2006-01-02T15:04:05.000Z"
+)
+
+const (
+	DefaultMaxProcs = 5
 )
 
 var BytesPerKB = float64(1024)
@@ -523,6 +528,20 @@ func _hasAnyAtExtreme(value string, fn func(string, string) bool, queries []stri
 		}
 	}
 	return false
+}
+
+func maxProcs() int {
+	maxProcs, err := strconv.ParseInt(os.Getenv(GoMaxProcsKey), 10, 0)
+	if err != nil {
+		return DefaultMaxProcs
+	}
+
+	maxProcsInt := int(maxProcs)
+	if maxProcs < 1 {
+		return DefaultMaxProcs
+	}
+
+	return maxProcsInt
 }
 
 func customQuote(s string) string {

--- a/src/misc.go
+++ b/src/misc.go
@@ -537,7 +537,7 @@ func maxProcs() int {
 	}
 
 	maxProcsInt := int(maxProcs)
-	if maxProcs < 1 {
+	if maxProcsInt < 1 {
 		return DefaultMaxProcs
 	}
 

--- a/src/misc.go
+++ b/src/misc.go
@@ -577,5 +577,5 @@ func newExpirableCacheValueWithOffset(v interface{}, offset time.Duration) *expi
 }
 
 var newExpirableCacheValue = func(v interface{}) *expirableCacheValue {
-	return newExpirableCacheValueWithOffset(v, 10*time.Minute)
+	return newExpirableCacheValueWithOffset(v, time.Hour)
 }

--- a/src/remote.go
+++ b/src/remote.go
@@ -396,6 +396,7 @@ func indexContent(mask int) bool {
 type upsertOpt struct {
 	parentId       string
 	fsAbsPath      string
+	relToRootPath  string
 	src            *File
 	dest           *File
 	mask           int

--- a/src/types.go
+++ b/src/types.go
@@ -228,8 +228,35 @@ func (cl ByPrecedence) Less(i, j int) bool {
 		return true
 	}
 
-	rank1, rank2 := opPrecedence[cl[i].Op()], opPrecedence[cl[j].Op()]
-	return rank1 < rank2
+	c1, c2 := cl[i], cl[j]
+	c1Op, c2Op := c1.Op(), c2.Op()
+
+	rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
+
+	if true {
+		return rank1 < rank2
+	}
+
+	if c1Op != c2Op {
+		rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
+		return rank1 < rank2
+	}
+
+	if c1.Dest != nil {
+		return changeComparisonLess_(c1, c2)
+	}
+
+	return changeComparisonLess_(c2, c1)
+}
+
+func changeComparisonLess_(c1, c2 *Change) bool {
+	if c1.Dest != nil {
+		if c2.Dest == nil {
+			return false
+		}
+		return c1.Dest.Size < c2.Dest.Size
+	}
+	return true
 }
 
 func (cl ByPrecedence) Len() int {
@@ -363,6 +390,9 @@ func (c *Change) crudValue() CrudValue {
 }
 
 func (c *Change) op() Operation {
+	if c == nil {
+		return OpNone
+	}
 	if c.Src == nil && c.Dest == nil {
 		return OpNone
 	}

--- a/src/types.go
+++ b/src/types.go
@@ -480,6 +480,10 @@ func (c *Change) checkIndexExistance() (bool, error) {
 }
 
 func (c *Change) Op() Operation {
+	if c == nil {
+		return OpNone
+	}
+
 	op := c.op()
 	if c.Force {
 		if op == OpModConflict {

--- a/src/types.go
+++ b/src/types.go
@@ -229,41 +229,7 @@ func (cl ByPrecedence) Less(i, j int) bool {
 	}
 
 	c1, c2 := cl[i], cl[j]
-	c1Op, c2Op := c1.Op(), c2.Op()
-
-	if false {
-		rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
-		return rank1 < rank2
-	}
-
-	if c1Op != c2Op {
-		rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
-		return rank1 < rank2
-	}
-
-	if c1.Dest != nil {
-		return changeComparisonLess_(c1, c2)
-	}
-
-	return changeComparisonLess_(c2, c1)
-}
-
-func changeComparisonLess_(c1, c2 *Change) bool {
-	if c1.Dest == nil {
-		return true
-	}
-
-	if c2.Dest == nil {
-		return false
-	}
-
-	if c1.Dest.Size != c2.Dest.Size {
-		return c1.Dest.Size < c2.Dest.Size
-	}
-
-	// This comparison is necessary say when dealing
-	// with directories and you need parents created first.
-	return len(c1.Path) < len(c2.Path)
+	return opPrecedence[c1.Op()] < opPrecedence[c2.Op()]
 }
 
 func (cl ByPrecedence) Len() int {

--- a/src/types.go
+++ b/src/types.go
@@ -231,9 +231,8 @@ func (cl ByPrecedence) Less(i, j int) bool {
 	c1, c2 := cl[i], cl[j]
 	c1Op, c2Op := c1.Op(), c2.Op()
 
-	rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
-
-	if true {
+	if false {
+		rank1, rank2 := opPrecedence[c1Op], opPrecedence[c2Op]
 		return rank1 < rank2
 	}
 
@@ -250,13 +249,21 @@ func (cl ByPrecedence) Less(i, j int) bool {
 }
 
 func changeComparisonLess_(c1, c2 *Change) bool {
-	if c1.Dest != nil {
-		if c2.Dest == nil {
-			return false
-		}
+	if c1.Dest == nil {
+		return true
+	}
+
+	if c2.Dest == nil {
+		return false
+	}
+
+	if c1.Dest.Size != c2.Dest.Size {
 		return c1.Dest.Size < c2.Dest.Size
 	}
-	return true
+
+	// This comparison is necessary say when dealing
+	// with directories and you need parents created first.
+	return len(c1.Path) < len(c2.Path)
 }
 
 func (cl ByPrecedence) Len() int {
@@ -397,7 +404,11 @@ func (c *Change) op() Operation {
 		return OpNone
 	}
 
-	indexingOnly := c.g.opts.indexingOnly
+	indexingOnly := false
+	if c.g != nil && c.g.opts != nil {
+		indexingOnly = c.g.opts.indexingOnly
+	}
+
 	if c.Src != nil && c.Dest == nil {
 		return indexExistanceOrDeferTo(c, OpAdd, indexingOnly)
 	}


### PR DESCRIPTION
This PR addresses issues #315 and #77. It also fixes the bugs and complexity in PR https://github.com/odeke-em/drive/pull/210.

* Introduces a flag `--v` for `verbosity` during push to see step by step information.
* Introduces $GOMAXPROCS to be the number of max parallel uploads. Default is 4.


To test it out:

```shell
$ go get -u github.com/odeke-em/drive
$ cd $GOPATH/src/github.com/odeke-em/drive
$ git checkout easier-parallel-uploads-caching && git fetch --all
$ go get ./drive-gen && drive-gen
$ drive push -v [paths...]
```