### PR TITLE
pull: cleaned up goroutine rationer + verbose opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,14 @@ $ drive pull --exclude-ops "delete,update" vines
 $ drive push --exclude-ops "create" sensitive_files
 ```
 
++ To show more information during pushes or pulls e.g show the current operation,
+pass in option `--verbose` e.g:
+
+```shell
+$ drive pull --verbose 2015/Photos content
+$ drive push --verbose Music Fall2014
+```
+
 ### Publishing
 
 The `pub` command publishes a file or directory globally so that anyone can view it on the web using the link returned.

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -467,6 +467,8 @@ type pullCmd struct {
 	ignoreNameClashes *bool
 	skipMimeKey       *string
 	explicitlyExport  *bool
+
+	verbose *bool
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -488,6 +490,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.byId = fs.Bool(drive.CLIOptionId, false, "pull by id instead of path")
 	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
 	cmd.explicitlyExport = fs.Bool(drive.CLIOptionExplicitlyExport, false, drive.DescExplicitylPullExports)
+	cmd.verbose = fs.Bool(drive.CLIOptionVerboseKey, false, drive.DescVerbose)
 
 	return fs
 }
@@ -528,6 +531,7 @@ func (cmd *pullCmd) Run(args []string) {
 		ExcludeCrudMask:   excludeCrudMask,
 		ExplicitlyExport:  *cmd.explicitlyExport,
 		Meta:              &meta,
+		Verbose:           *cmd.verbose,
 	}
 
 	if *cmd.matches {
@@ -580,7 +584,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.ignoreNameClashes = fs.Bool(drive.CLIOptionIgnoreNameClashes, false, drive.DescIgnoreNameClashes)
 	cmd.excludeOps = fs.String(drive.CLIOptionExcludeOperations, "", drive.DescExcludeOps)
 	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
-	cmd.verbose = fs.Bool(drive.CLIOptionVerboseShortKey, false, drive.DescVerbose)
+	cmd.verbose = fs.Bool(drive.CLIOptionVerboseKey, false, drive.DescVerbose)
 	return fs
 }
 

--- a/src/push.go
+++ b/src/push.go
@@ -292,7 +292,7 @@ func (g *Commands) playPushChanges(cl []*Change, opMap *map[Operation]sizeCounte
 	}
 
 	throttle := time.Tick(time.Duration(1e9 / n))
-	canPrintSteps := g.opts.Verbose && g.opts.canPrompt()
+	canPrintSteps := g.opts.Verbose || g.opts.canPrompt()
 
 	sort.Sort(ByPrecedence(cl))
 


### PR DESCRIPTION
This PR addresses issue #332 and in particular, details are:
+ Cleaned up the legacy goroutine rationer for pulls.
+ Added a verbose option for showing the current operation.