### PR TITLE
url command implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   - [DesktopEntry](#desktopentry)
   - [Command Aliases](#command-aliases)
   - [Index Prune](#index-prune)
+  - [Url](#url)
 - [Revoking Account Access](#revoking-account-access)
 - [Uninstalling](#uninstalling)
 - [Applying patches](#applying-patches)
@@ -775,6 +776,14 @@ To combine both operations (prune and then fetch) for indices:
 $ drive index --all-ops
 ```
 
+## Url
+
+The url command prints out the url of a file. It allows you to specify multiple paths relative to root or even by id
+
+```shell
+$ drive url Photos/2015/07/Releases intros/flux
+$ drive url --id  0Bz5qQkvRAeVEV0JtZl4zVUZFWWx  1Pwu8lzYc9RTPTEpwYjhRMnlSbDQ 0Cz5qUrvDBeX4RUFFbFZ5UXhKZm8
+```
 
 ### Revoking Account Access
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -78,6 +78,7 @@ func main() {
 	bindCommandWithAliases(drive.VersionKey, drive.Version, &versionCmd{}, []string{})
 	bindCommandWithAliases(drive.NewKey, drive.DescNew, &newCmd{}, []string{})
 	bindCommandWithAliases(drive.IndexKey, drive.DescIndex, &indexCmd{}, []string{})
+	bindCommandWithAliases(drive.UrlKey, drive.DescUrl, &urlCmd{}, []string{})
 
 	command.DefineHelp(&helpCmd{})
 	command.ParseAndRun()
@@ -160,6 +161,26 @@ func (cmd *quotaCmd) Run(args []string) {
 	exitWithError(drive.New(context, &drive.Options{
 		Path: path,
 	}).About(drive.AboutQuota))
+}
+
+type urlCmd struct {
+	byId *bool
+}
+
+func (cmd *urlCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.byId = fs.Bool(drive.CLIOptionId, false, "resolve url by id instead of path")
+	return fs
+}
+
+func (cmd *urlCmd) Run(args []string) {
+	sources, context, path := preprocessArgsByToggle(args, *cmd.byId)
+
+	opts := drive.Options{
+		Path:    path,
+		Sources: sources,
+	}
+
+	exitWithError(drive.New(context, &opts).Url(*cmd.byId))
 }
 
 type listCmd struct {

--- a/src/help.go
+++ b/src/help.go
@@ -82,6 +82,7 @@ const (
 	FolderKey             = "folder"
 	MimeKey               = "mime-key"
 	DriveRepoRelPath      = "github.com/odeke-em/drive"
+	UrlKey                = "url"
 )
 
 const (
@@ -132,6 +133,7 @@ const (
 	DescNotOwner           = "ignore elements owned by these users"
 	DescNew                = "create a new file/folder"
 	DescAllIndexOperations = "perform all the index related operations"
+	DescUrl                = "returns the url of each file"
 	DescVerbose            = "show step by step information verbosely"
 )
 

--- a/src/publish.go
+++ b/src/publish.go
@@ -38,7 +38,7 @@ func (c *Commands) remFileResolve(relToRoot string, byId bool) (*File, error) {
 
 func (c *Commands) pub(relToRoot string, byId bool) (err error) {
 	file, err := c.remFileResolve(relToRoot, byId)
-	if err != nil {
+	if err != nil || file == nil {
 		return err
 	}
 
@@ -47,9 +47,8 @@ func (c *Commands) pub(relToRoot string, byId bool) (err error) {
 	if err != nil {
 		return
 	}
-	if hasExportLinks(file) {
-		link = file.AlternateLink
-	}
+
+	link = file.Url()
 
 	if byId {
 		relToRoot = fmt.Sprintf("%s aka %s", relToRoot, file.Name)

--- a/src/types.go
+++ b/src/types.go
@@ -185,6 +185,22 @@ func fauxLocalFile(relToRootPath string) *File {
 	}
 }
 
+func (f *File) Url() (url string) {
+	if f == nil {
+		return
+	}
+
+	if hasExportLinks(f) {
+		return f.AlternateLink
+	}
+
+	if f.Id != "" {
+		url = DriveResourceHostURL + f.Id
+	}
+
+	return
+}
+
 func (f *File) localAliases(prefix string) (aliases []string) {
 	aliases = append(aliases, prefix)
 

--- a/src/url.go
+++ b/src/url.go
@@ -1,0 +1,50 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+func (g *Commands) Url(byId bool) error {
+	resolver := g.rem.FindByPath
+	if byId {
+		resolver = g.rem.FindById
+	}
+
+	kvChan := make(chan *keyValue)
+
+	go func() {
+		defer close(kvChan)
+
+		for _, source := range g.opts.Sources {
+			f, err := resolver(source)
+
+			kv := keyValue{key: source, value: err}
+			if err == nil {
+				kv.value = f.Url()
+			}
+
+			kvChan <- &kv
+		}
+	}()
+
+	for kv := range kvChan {
+		switch kv.value.(type) {
+		case error:
+			g.log.LogErrf("%s: %s\n", kv.key, kv.value)
+		default:
+			g.log.Logf("%s: %s\n", kv.key, kv.value)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR addresses issue #348 and allows for users to get the urls of files either by relative path or by id

##### Examples
```shell
$ drive url Photos/2015/07/Releases intros/flux
$ drive url --id  0Bz5qQkvRAeVEV0JtZl4zVUZFWWx  1Pwu8lzYc9RTPTEpwYjhRMnlSbDQ 0Cz5qUrvDBeX4RUFFbFZ5UXhKZm8
```