### PR TITLE
open command added

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,15 @@ $ drive url Photos/2015/07/Releases intros/flux
 $ drive url --id  0Bz5qQkvRAeVEV0JtZl4zVUZFWWx  1Pwu8lzYc9RTPTEpwYjhRMnlSbDQ 0Cz5qUrvDBeX4RUFFbFZ5UXhKZm8
 ```
 
+## Open
+
+The open command allows for files to be opened by the default file browser, default web browser, either by path or by id for paths that exist atleast remotely
+
+```shell
+$ drive open --file-browser=false --web-browser f1/f2/f3 jamaican.mp4
+$ drive open --file-browser --id 0Bz8qQkpZAeV9T1PObvs2Y3BMQEj 0Y9jtQkpXAeV9M1PObvs4Y3BNRFk
+```
+
 ### Revoking Account Access
 
 To revoke OAuth Access of drive to your account, when logged in with your Google account, go to https://security.google.com/settings/security/permissions and revoke the desired permissions

--- a/src/help.go
+++ b/src/help.go
@@ -66,6 +66,7 @@ const (
 	NoPromptKey           = "no-prompt"
 	SizeKey               = "size"
 	NameKey               = "name"
+	OpenKey               = "open"
 	OriginalNameKey       = "oname"
 	ModTimeKey            = "modt"
 	LastViewedByMeTimeKey = "lvt"
@@ -133,6 +134,7 @@ const (
 	DescNotOwner           = "ignore elements owned by these users"
 	DescNew                = "create a new file/folder"
 	DescAllIndexOperations = "perform all the index related operations"
+	DescOpen               = "open a file in the appropriate filemanager or default browser"
 	DescUrl                = "returns the url of each file"
 	DescVerbose            = "show step by step information verbosely"
 )
@@ -157,6 +159,9 @@ const (
 	CLIOptionAllIndexOperations = "all-ops"
 	CLIOptionVerboseKey         = "verbose"
 	CLIOptionVerboseShortKey    = "v"
+	CLIOptionOpen               = "open"
+	CLIOptionWebBrowser         = "web-browser"
+	CLIOptionFileBrowser        = "file-browser"
 )
 
 const (


### PR DESCRIPTION
This PR addresses issue #351.
It provides the functionality for drive to open files that exist at least remotely, in the default file browser or the designated web browser, either by relative path or by id.

#### Examples
```shell
$ drive open --file-browser=false --web-browser f1/f2/f3 jamaican.mp4
$ drive open --file-browser --id 0Bz8qQkpZAeV9T1PObvs2Y3BMQEj 0Y9jtQkpXAeV9M1PObvs4Y3BNRFk
```