### PR TITLE
serve-url: use open entry point instead of hostURL

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -48,6 +48,9 @@ const (
 
 	// Google Drive webpage host
 	DriveResourceHostURL = "https://googledrive.com/host/"
+
+	// Google Drive entry point
+	DriveResourceEntryURL = "https://drive.google.com"
 )
 
 const (

--- a/src/types.go
+++ b/src/types.go
@@ -195,7 +195,7 @@ func (f *File) Url() (url string) {
 	}
 
 	if f.Id != "" {
-		url = DriveResourceHostURL + f.Id
+		url = fmt.Sprintf("%s/open?id=%s", DriveResourceEntryURL, f.Id)
 	}
 
 	return


### PR DESCRIPTION
This PR addresses issue #354.

Use the standard Google Drive entry point url instead of the
hostURL which is useful for published files but not for private ones.