### PR TITLE
findByPath: handle files clashing by path

### DIFF
--- a/src/pull.go
+++ b/src/pull.go
@@ -186,23 +186,28 @@ func (g *Commands) PullMatches() (err error) {
 func (g *Commands) PullPiped(byId bool) (err error) {
 	resolver := g.rem.FindByPath
 	if byId {
-		resolver = g.rem.FindById
+		resolver = g.rem.FindByIdMulti
 	}
 
 	for _, relToRootPath := range g.opts.Sources {
-		rem, err := resolver(relToRootPath)
+		remotes, err := resolver(relToRootPath)
+
 		if err != nil {
 			return fmt.Errorf("%s: %v", relToRootPath, err)
 		}
-		if rem == nil {
-			continue
-		}
 
-		err = g.pullAndDownload(relToRootPath, os.Stdout, rem, true)
-		if err != nil {
-			return err
+		for _, rem := range remotes {
+			if rem == nil {
+				continue
+			}
+
+			err = g.pullAndDownload(relToRootPath, os.Stdout, rem, true)
+			if err != nil {
+				g.log.LogErrf("pullPiped:: %s %s: %v\n", relToRootPath, rem.Id, err)
+			}
 		}
 	}
+
 	return nil
 }
 

--- a/src/url.go
+++ b/src/url.go
@@ -32,7 +32,7 @@ func (g *Commands) Url(byId bool) error {
 func (g *Commands) urler(byId bool) (kvChan chan *keyValue) {
 	resolver := g.rem.FindByPath
 	if byId {
-		resolver = g.rem.FindById
+		resolver = g.rem.FindByIdMulti
 	}
 
 	kvChan = make(chan *keyValue)
@@ -41,14 +41,16 @@ func (g *Commands) urler(byId bool) (kvChan chan *keyValue) {
 		defer close(kvChan)
 
 		for _, source := range g.opts.Sources {
-			f, err := resolver(source)
+			files, err := resolver(source)
 
-			kv := keyValue{key: source, value: err}
-			if err == nil {
-				kv.value = f.Url()
+			for _, f := range files {
+				kv := keyValue{key: source, value: err}
+				if err == nil {
+					kv.value = f.Url()
+				}
+
+				kvChan <- &kv
 			}
-
-			kvChan <- &kv
 		}
 	}()
 


### PR DESCRIPTION
This PR is a work in progress (not complete) to fix up a couple of bugs that were caused due to the design remote findBy* functions with local filesystem inherent behaviour for a remote that allows path duplication e.g
`FindByPath(...) previously returned a single file`
However
`FindByPath(...) actually picked the first path presented to it` because Google Drive can allow for different files to have the same relative path, with no problem but the local file system will not.

With the new behaviour, a FindByPath call should return all found files.

This kind of old behaviour causes issues like not all the clashes being listed, not fully urlifying nor opening files, not properling `list-ing`, `stat-ing` and many others.
