### PR TITLE
coerce csv,tsv to officedocs

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -413,7 +413,7 @@ func NonEmptyTrimmedStrings(v ...string) (splits []string) {
 }
 
 var regExtStrMap = map[string]string{
-	"csv":   "text/csv",
+	"csv":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 	"html?": "text/html",
 	"te?xt": "text/plain",
 	"xml":   "text/xml",
@@ -453,6 +453,7 @@ var regExtStrMap = map[string]string{
 
 	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 	"pptx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.presentation",
+	"tsv":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 	"xlsx?": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }
 


### PR DESCRIPTION
This is because Google Drive fails to convert text/csv types
to Spreadsheets, however with the Spreadsheet coercion it alludes
them to Spreadsheets but on final open it will fully convert it to a
Google Sheet. See the tricky thing though is that trying to force
csv/tsv directly to Google Sheets fails since Google Docs catches this
and then reverts them to text documents.