### PR TITLE
fixed mimeType for pptx?

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -452,7 +452,7 @@ var regExtStrMap = map[string]string{
 	"mp3": "audio/mpeg",
 
 	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"pptx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.presentation",
+	"pptx?": "application/vnd.ms-powerpoint",
 	"tsv":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 	"xlsx?": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }


### PR DESCRIPTION
This PR fixes issue #368. I figured out the mimeType by uploading a pptx file using the WebUI and then
```shell
$ drive stat test.pptx
....
MimeType                  application/vnd.ms-powerpoint 
....
````

# Before
<img width="436" alt="screen shot 2015-09-08 at 12 12 20 am" src="https://cloud.githubusercontent.com/assets/4898263/9727795/f4b7db9e-55bf-11e5-9c07-1cdb72f14aa5.png">

<img width="970" alt="screen shot 2015-09-08 at 12 20 34 am" src="https://cloud.githubusercontent.com/assets/4898263/9727797/fc7d5a8e-55bf-11e5-90e8-35a0b34caf04.png">


# After
<img width="435" alt="screen shot 2015-09-08 at 12 22 50 am" src="https://cloud.githubusercontent.com/assets/4898263/9727799/07662d72-55c0-11e5-8977-25d616e4e8a4.png">

<img width="956" alt="screen shot 2015-09-08 at 12 23 14 am" src="https://cloud.githubusercontent.com/assets/4898263/9727802/0ee45e7a-55c0-11e5-93c8-3954d3cc2b0d.png">