### PR TITLE
move: compose multiple errors into one

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -16,6 +16,7 @@ package drive
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -618,4 +619,25 @@ func newExpirableCacheValueWithOffset(v interface{}, offset time.Duration) *expi
 
 var newExpirableCacheValue = func(v interface{}) *expirableCacheValue {
 	return newExpirableCacheValueWithOffset(v, time.Hour)
+}
+
+func reComposeError(prevErr error, messages ...string) error {
+	if len(messages) < 1 {
+		return prevErr
+	}
+
+	joinedMessage := messages[0]
+	for i, n := 1, len(messages); i < n; i++ {
+		joinedMessage = fmt.Sprintf("%s\n%s", joinedMessage, messages[i])
+	}
+
+	if prevErr == nil {
+		if len(joinedMessage) < 1 {
+			return nil
+		}
+	} else {
+		joinedMessage = fmt.Sprintf("%v\n%s", prevErr, joinedMessage)
+	}
+
+	return errors.New(joinedMessage)
 }

--- a/src/move.go
+++ b/src/move.go
@@ -25,13 +25,15 @@ type moveOpt struct {
 	byId bool
 }
 
-func (g *Commands) Move(byId bool) (err error) {
+func (g *Commands) Move(byId bool) error {
 	argc := len(g.opts.Sources)
 	if argc < 2 {
 		return fmt.Errorf("move: expected <src> [src...] <dest>, instead got: %v", g.opts.Sources)
 	}
 
 	rest, dest := g.opts.Sources[:argc-1], g.opts.Sources[argc-1]
+
+	var composedError error = nil
 
 	for _, src := range rest {
 		prefix := commonPrefix(src, dest)
@@ -47,14 +49,13 @@ func (g *Commands) Move(byId bool) (err error) {
 			byId: byId,
 		}
 
-		err = g.move(&opt)
-		if err != nil {
-			// TODO: Actually throw the error? Impact on UX if thrown?
-			fmt.Printf("move: %s: %v\n", src, err)
+		if err := g.move(&opt); err != nil {
+			message := fmt.Sprintf("move: %s: %v", src, err)
+			composedError = reComposeError(composedError, message)
 		}
 	}
 
-	return nil
+	return composedError
 }
 
 func (g *Commands) move(opt *moveOpt) (err error) {


### PR DESCRIPTION
This PR addresses issue #379 by ensuring that errors get well composed if any and then returned at the end.

Given 
### Before
```shell
$ drive push proof.go no-chill.mp4 proofs && echo "Done" || echo -e "Failed \a"
move: /proof.go: src('/proof.go') remote path doesn't exist
move: /no-chill.mp4: src('/no-chill.mp4') remote path doesn't exist
"Done"
```

### After
```shell
$ drive push proof.go no-chill.mp4 proofs && echo "Done" || echo -e "Failed \a"
move: /proof.go: src('/proof.go') remote path doesn't exist
move: /no-chill.mp4: src('/no-chill.mp4') remote path doesn't exist
Failed
```