### PR TITLE
quota: respect no-prompt on exceeded err

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -122,7 +122,12 @@ func (g *Commands) Push() (err error) {
 	}
 
 	if unSafe {
-		g.log.LogErrf(" projected size: (%d) %s\n", pushSize, prettyBytes(pushSize))
+		unSafeQuotaMsg := fmt.Sprintf("projected size: (%d) %s\n", pushSize, prettyBytes(pushSize))
+		if !g.opts.canPrompt() {
+			return fmt.Errorf("quota: noPrompt is set yet for quota %s", unSafeQuotaMsg)
+		}
+
+		g.log.LogErrf(" %s", unSafeQuotaMsg)
 		if !promptForChanges() {
 			return
 		}


### PR DESCRIPTION
This PR addresses issue #386 

### Before
```shell
$ drive push --no-prompt resty_demo.mov && echo done
Resolving...
 projected size: (1346167232) 1.25GB
Proceed with the changes? [Y/n]:
```

### After
```
$ drive push --no-prompt resty_demmov && echo done || echo "aborted"
Resolving...
quota: noPrompt is set yet for quota projected size: (1346167232) 1.25GB

aborted
```