### PR TITLE
push-piped: update ModTime on push

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -203,10 +203,15 @@ func (g *Commands) PushPiped() (err error) {
 			}
 		}
 
+		fauxSrc := DupFile(rem)
+		if fauxSrc != nil {
+			fauxSrc.ModTime = time.Now()
+		}
+
 		args := upsertOpt{
 			parentId:       parent.Id,
 			fsAbsPath:      relToRootPath,
-			src:            rem,
+			src:            fauxSrc,
 			dest:           rem,
 			mask:           g.opts.TypeMask,
 			nonStatable:    true,

--- a/src/types.go
+++ b/src/types.go
@@ -136,6 +136,10 @@ func NewRemoteFile(f *drive.File) *File {
 }
 
 func DupFile(f *File) *File {
+	if f == nil {
+		return f
+	}
+
 	return &File{
 		BlobAt:      f.BlobAt,
 		Etag:        f.Etag,


### PR DESCRIPTION
This PR fixes issue #392.

What was happening was the both source and destination were being derived from the remote file and no actual modTime update was being done before push.