### PR TITLE
unknown errors now retryable by default

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -75,8 +75,22 @@ func retryableErrorCheck(v interface{}) (ok, retryable bool) {
 		return
 	}
 
+	if pr.last == nil {
+		ok = true
+		return
+	}
+
 	err, assertOk := pr.last.(*googleapi.Error)
-	if !assertOk || err == nil {
+	// In relation to https://github.com/google/google-api-go-client/issues/93
+	// where not every error is of googleapi.Error instance e.g io timeout errors
+	// etc, let's assume that non-nil errors are retryable
+
+	if !assertOk {
+		retryable = true
+		return
+	}
+
+	if err == nil {
 		ok = true
 		return
 	}


### PR DESCRIPTION
This PR addresses issues https://github.com/odeke-em/drive/issues/358, https://github.com/odeke-em/drive/issues/345, https://github.com/odeke-em/drive/issues/371 and others.

In relation to a large set of unknown errors, moreover looking at
https://github.com/google/google-api-go-client/issues/93
where we are type casting to a googleapi.Error yet errors could be
dial/net related errors, it is safer to make the largely unknown errors
retryable.

This actually helps a lot say when downloading files and the connection
is cut out maybe due to WiFi trips or going underground.