### PR TITLE
Update google api dependencies to use canonical path

### DIFF
--- a/src/about.go
+++ b/src/about.go
@@ -17,7 +17,7 @@ package drive
 import (
 	"fmt"
 
-	drive "github.com/google/google-api-go-client/drive/v2"
+	drive "google.golang.org/api/drive/v2"
 	"github.com/odeke-em/log"
 )
 

--- a/src/remote.go
+++ b/src/remote.go
@@ -32,7 +32,7 @@ import (
 	"github.com/odeke-em/drive/config"
 	"github.com/odeke-em/statos"
 
-	drive "github.com/google/google-api-go-client/drive/v2"
+	drive "google.golang.org/api/drive/v2"
 	expb "github.com/odeke-em/exponential-backoff"
 )
 

--- a/src/stat.go
+++ b/src/stat.go
@@ -16,7 +16,7 @@ package drive
 
 import (
 	"fmt"
-	drive "github.com/google/google-api-go-client/drive/v2"
+	drive "google.golang.org/api/drive/v2"
 	"github.com/odeke-em/log"
 	"path/filepath"
 	"strings"

--- a/src/types.go
+++ b/src/types.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	drive "github.com/google/google-api-go-client/drive/v2"
+	drive "google.golang.org/api/drive/v2"
 	"github.com/odeke-em/drive/config"
 )
 


### PR DESCRIPTION
See https://golang.org/s/go14customimport for an explanation.
Fixes the below warning:
package github.com/google/google-api-go-client/googleapi: code in
directory
$GOROOT/src/github.com/google/google-api-go-client/googleapi
expects import "google.golang.org/api/googleapi"