### PR TITLE
push: pass in depth for mounted push

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -379,6 +379,7 @@ func lonePush(g *Commands, parent, absPath, path string) (cl, clashes []*Change,
 		base:   absPath,
 		remote: r,
 		local:  l,
+		depth:  g.opts.Depth,
 	}
 
 	return g.resolveChangeListRecv(clr)


### PR DESCRIPTION
This PR addresses issue #415 

```shell
$ cd testDrive
$ ls -l ~/Desktop/continuations
total 12
-rwxrwxr-x 1 emmanuel emmanuel 7579 Jan 13  2015 gen
-rw-rw-r-- 1 emmanuel emmanuel  709 Dec 30  2014 gen.c
$ drive push -m ~/Desktop/continuations .
Resolving...
+ /continuations
+ /continuations/gen
+ /continuations/gen.c
Addition count 3 src: 8.09KB
Proceed with the changes? [Y/n]:
```