### PR TITLE
fix-clashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ $ drive push -piped path
 ```
 
 + Note:
-  * In relation to [#107](https://github.com/odeke-em/drive/issues/107) and numerous other issues related to confusion about clashing paths, drive will abort on trying to deal with clashing names. To turn off this safety, pass in flag `--ignore-name-clashes`.
+  * In response to [#107](https://github.com/odeke-em/drive/issues/107) and numerous other issues related to confusion about clashing paths, drive can now auto-rename clashing files. Use flag `--fix-clashes` during a `pull` or `push`, and drive will try to rename clashing files by adding a unique suffix at the end of the name, but right before the extension of a file (if the extension exists). If you haven't passed in the above `--fix-clashes` flag, drive will abort on trying to deal with clashing names. If you'd like to turn off this safety, pass in flag `--ignore-name-clashes`
   * In relation to [#57](https://github.com/odeke-em/drive/issues/57) and [@rakyll's #49](https://github.com/rakyll/drive/issues/49).
    A couple of scenarios in which data was getting totally clobbered and unrecoverable, drive now tries to play it safe and warn you if your data could potentially be lost e.g during a to-disk clobber for which you have no backup. At least with a push you have the luxury of untrashing content. To disable this safety, run drive with flag `-ignore-conflict` e.g:
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -523,6 +523,7 @@ type pullCmd struct {
 	ignoreNameClashes *bool
 	skipMimeKey       *string
 	explicitlyExport  *bool
+	fixClashes        *bool
 
 	verbose *bool
 	depth   *int
@@ -549,6 +550,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.explicitlyExport = fs.Bool(drive.CLIOptionExplicitlyExport, false, drive.DescExplicitylPullExports)
 	cmd.verbose = fs.Bool(drive.CLIOptionVerboseKey, false, drive.DescVerbose)
 	cmd.depth = fs.Int(drive.DepthKey, drive.DefaultMaxTraversalDepth, "max traversal depth")
+	cmd.fixClashes = fs.Bool(drive.CLIOptionFixClashesKey, false, drive.DescFixClashes)
 
 	return fs
 }
@@ -589,6 +591,7 @@ func (cmd *pullCmd) Run(args []string) {
 		Meta:              &meta,
 		Verbose:           *cmd.verbose,
 		Depth:             *cmd.depth,
+		FixClashes:        *cmd.fixClashes,
 	}
 
 	if *cmd.matches {
@@ -623,6 +626,7 @@ type pushCmd struct {
 	skipMimeKey       *string
 	verbose           *bool
 	depth             *int
+	fixClashes        *bool
 }
 
 func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -644,6 +648,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.skipMimeKey = fs.String(drive.CLIOptionSkipMime, "", drive.DescSkipMime)
 	cmd.verbose = fs.Bool(drive.CLIOptionVerboseKey, false, drive.DescVerbose)
 	cmd.depth = fs.Int(drive.DepthKey, drive.DefaultMaxTraversalDepth, "max traversal depth")
+	cmd.fixClashes = fs.Bool(drive.CLIOptionFixClashesKey, false, drive.DescFixClashes)
 	return fs
 }
 
@@ -656,6 +661,7 @@ func (cmd *pushCmd) Run(args []string) {
 		options := cmd.createPushOptions()
 		options.Path = path
 		options.Sources = sources
+		options.FixClashes = *cmd.fixClashes
 
 		if *cmd.piped {
 			exitWithError(drive.New(context, options).PushPiped())

--- a/src/commands.go
+++ b/src/commands.go
@@ -86,6 +86,7 @@ type Options struct {
 	Md5sum            bool
 	indexingOnly      bool
 	Verbose           bool
+	FixClashes        bool
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -142,6 +142,7 @@ const (
 	DescOpen               = "open a file in the appropriate filemanager or default browser"
 	DescUrl                = "returns the url of each file"
 	DescVerbose            = "show step by step information verbosely"
+	DescFixClashes         = "fix clashes by renaming files"
 )
 
 const (
@@ -167,6 +168,7 @@ const (
 	CLIOptionOpen               = "open"
 	CLIOptionWebBrowser         = "web-browser"
 	CLIOptionFileBrowser        = "file-browser"
+	CLIOptionFixClashesKey      = "fix-clashes"
 )
 
 const (

--- a/src/push.go
+++ b/src/push.go
@@ -75,6 +75,14 @@ func (g *Commands) Push() (err error) {
 	}
 
 	if len(clashes) >= 1 {
+		if g.opts.FixClashes {
+			err := autoRenameClashes(g, clashes)
+			if err == nil {
+				g.log.Logln("Clashes were fixed, try pulling again.")
+			}
+			return err
+		}
+
 		warnClashesPersist(g.log, clashes)
 		return ErrClashesDetected
 	}

--- a/src/remote.go
+++ b/src/remote.go
@@ -66,7 +66,8 @@ const (
 var (
 	ErrPathNotExists                  = errors.New("remote path doesn't exist")
 	ErrNetLookup                      = errors.New("net lookup failed")
-	ErrClashesDetected                = fmt.Errorf("clashes detected. use `%s` to override this behavior", CLIOptionIgnoreNameClashes)
+	ErrClashesDetected                = fmt.Errorf("clashes detected. Use `%s` to override this behavior or `%s` to try fixing this",
+										CLIOptionIgnoreNameClashes, CLIOptionFixClashesKey)
 	ErrGoogleApiInvalidQueryHardCoded = errors.New("googleapi: Error 400: Invalid query, invalid")
 )
 


### PR DESCRIPTION
This pull request is a draft. I would like to know if you are interested in implementing such a mechanism to automatically rename files on drive to prevent name clashes. Right now, if some clashes occur, user is advised to go to drive and resolve name conflicts before doing pull. While this is probably the safest option, I personally wouldn't bother when there is more than a few clashes. This functionality is racy and may not be safe but it does automate the task and I think may still be useful if users are properly warned. What do you think?

I don't know neither code base nor Go so I'm aware that the code itself requires polishing.