### PR TITLE
edit-file functionality added

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Listing Files](#listing-files)
   - [Stating Files](#stating-files)
   - [Retrieving md5 checksums](#retrieving-md5-checksums)
+  - [Editing Description](#editing-description)
   - [New File](#new-file)
   - [Quota](#quota)
   - [Features](#features)
@@ -707,6 +708,21 @@ $ drive new --mime-key presentation ProjectsPresentation
 $ drive new --mime-key sheet Hours2015Sept
 $ drive new --mime-key form taxForm2016 taxFormCounty
 $ drive new flux.txt oxen.pdf # Allow auto type resolution from the extension
+```
+
+### Editing Description
+
+You can edit the description of a file like this
+
+```shell
+$ drive edit-desc --description "This is a new file description" freshFolders/1.txt commonCore/
+$ drive edit-description --description "This is a new file description" freshFolders/1.txt commonCore/
+```
+
+Even more conveniently by piping content
+
+```shell
+$ cat fileDescriptions | drive edit-desc --piped  targetFile influx/1.txt
 ```
 
 ### Quota

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -80,6 +80,7 @@ func main() {
 	bindCommandWithAliases(drive.IndexKey, drive.DescIndex, &indexCmd{}, []string{})
 	bindCommandWithAliases(drive.UrlKey, drive.DescUrl, &urlCmd{}, []string{})
 	bindCommandWithAliases(drive.OpenKey, drive.DescOpen, &openCmd{}, []string{})
+	bindCommandWithAliases(drive.EditDescriptionKey, drive.DescEdit, &editDescriptionCmd{}, []string{})
 
 	command.DefineHelp(&helpCmd{})
 	command.ParseAndRun()
@@ -198,6 +199,39 @@ func (cmd *openCmd) Run(args []string) {
 	}
 
 	exitWithError(drive.New(context, &opts).Open(openType))
+}
+
+type editDescriptionCmd struct {
+	byId        *bool
+	description *string
+	piped       *bool
+}
+
+func (cmd *editDescriptionCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.byId = fs.Bool(drive.CLIOptionId, false, "open by id instead of path")
+	cmd.description = fs.String(drive.CLIOptionDescription, "", drive.DescDescription)
+	cmd.piped = fs.Bool(drive.CLIOptionPiped, false, drive.DescPiped)
+	return fs
+}
+
+func (cmd *editDescriptionCmd) Run(args []string) {
+	sources, context, path := preprocessArgsByToggle(args, *cmd.byId)
+
+	meta := map[string][]string{
+		drive.EditDescriptionKey: []string{*cmd.description},
+	}
+
+	if *cmd.piped {
+		meta[drive.PipedKey] = []string{fmt.Sprintf("%v", *cmd.piped)}
+	}
+
+	opts := drive.Options{
+		Meta:    &meta,
+		Path:    path,
+		Sources: sources,
+	}
+
+	exitWithError(drive.New(context, &opts).EditDescription(*cmd.byId))
 }
 
 type urlCmd struct {

--- a/src/edit.go
+++ b/src/edit.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"fmt"
+	"strings"
+)
+
+func noopOnFile(f *File) interface{} {
+	return f
+}
+
+func noopOnIgnorer(s string) bool {
+	return false
+}
+
+func (g *Commands) EditDescription(byId bool) (composedErr error) {
+	metaPtr := g.opts.Meta
+
+	if metaPtr == nil {
+		return fmt.Errorf("edit: no descriptions passed in")
+	}
+
+	meta := *metaPtr
+
+	description := strings.Join(meta[EditDescriptionKey], "\n")
+
+	if _, ok := meta[PipedKey]; ok {
+		clauses, err := readFileFromStdin(noopOnIgnorer)
+		if err != nil {
+			return err
+		}
+
+		description = strings.Join(clauses, "\n")
+	}
+
+	kvChan := resolver(g, byId, g.opts.Sources, noopOnFile)
+
+	for kv := range kvChan {
+		file, ok := kv.value.(*File)
+		if !ok {
+			g.log.LogErrf("%s: %s\n", kv.key, kv.value)
+			continue
+		}
+
+		if file == nil {
+			continue
+		}
+
+		updatedFile, err := g.rem.updateDescription(file.Id, description)
+		if err != nil {
+			composedErr = reComposeError(composedErr, fmt.Sprintf("%q %v", kv.key, err))
+		} else if updatedFile != nil {
+			name := fmt.Sprintf("%q", kv.key)
+			if kv.key != updatedFile.Id {
+				name = fmt.Sprintf("%s aka %q", name, updatedFile.Id)
+			}
+			g.log.LogErrf("Description updated for %s\n", name)
+		}
+	}
+
+	return
+}

--- a/src/help.go
+++ b/src/help.go
@@ -25,37 +25,40 @@ import (
 )
 
 const (
-	AboutKey      = "about"
-	AllKey        = "all"
-	CopyKey       = "copy"
-	DeleteKey     = "delete"
-	DiffKey       = "diff"
-	EmptyTrashKey = "emptytrash"
-	FeaturesKey   = "features"
-	HelpKey       = "help"
-	InitKey       = "init"
-	DeInitKey     = "deinit"
-	LinkKey       = "Link"
-	ListKey       = "list"
-	MoveKey       = "move"
-	OSLinuxKey    = "linux"
-	PullKey       = "pull"
-	PushKey       = "push"
-	PubKey        = "pub"
-	RenameKey     = "rename"
-	QuotaKey      = "quota"
-	ShareKey      = "share"
-	StatKey       = "stat"
-	TouchKey      = "touch"
-	TrashKey      = "trash"
-	UnshareKey    = "unshare"
-	UntrashKey    = "untrash"
-	UnpubKey      = "unpub"
-	VersionKey    = "version"
-	Md5sumKey     = "md5sum"
-	NewKey        = "new"
-	IndexKey      = "index"
-	PruneKey      = "prune"
+	AboutKey                = "about"
+	AllKey                  = "all"
+	CopyKey                 = "copy"
+	DeleteKey               = "delete"
+	EditDescriptionKey      = "edit-description"
+	EditDescriptionShortKey = "edit-desc"
+	DiffKey                 = "diff"
+	EmptyTrashKey           = "emptytrash"
+	FeaturesKey             = "features"
+	HelpKey                 = "help"
+	InitKey                 = "init"
+	DeInitKey               = "deinit"
+	LinkKey                 = "Link"
+	ListKey                 = "list"
+	MoveKey                 = "move"
+	OSLinuxKey              = "linux"
+	PipedKey                = "piped"
+	PullKey                 = "pull"
+	PushKey                 = "push"
+	PubKey                  = "pub"
+	RenameKey               = "rename"
+	QuotaKey                = "quota"
+	ShareKey                = "share"
+	StatKey                 = "stat"
+	TouchKey                = "touch"
+	TrashKey                = "trash"
+	UnshareKey              = "unshare"
+	UntrashKey              = "untrash"
+	UnpubKey                = "unpub"
+	VersionKey              = "version"
+	Md5sumKey               = "md5sum"
+	NewKey                  = "new"
+	IndexKey                = "index"
+	PruneKey                = "prune"
 
 	CoercedMimeKeyKey     = "coerced-mime"
 	DepthKey              = "depth"
@@ -98,6 +101,7 @@ const (
 	DescCopy                  = "copy remote paths to a destination"
 	DescDelete                = "deletes the items permanently. This operation is irreversible"
 	DescDiff                  = "compares local files with their remote equivalent"
+	DescEdit                  = "edit the attributes of a file"
 	DescEmptyTrash            = "permanently cleans out your trash"
 	DescExcludeOps            = "exclude operations"
 	DescFeatures              = "returns information about the features of your drive"
@@ -107,6 +111,7 @@ const (
 	DescDeInit                = "removes the user's credentials and initialized files"
 	DescList                  = "lists the contents of remote path"
 	DescMove                  = "move files/folders"
+	DescPiped                 = "get content in from standard input (stdin)"
 	DescQuota                 = "prints out information related to your quota space"
 	DescPublish               = "publishes a file and prints its publicly available url"
 	DescRename                = "renames a file/folder"
@@ -144,9 +149,11 @@ const (
 	DescUrl                = "returns the remote URL of each file"
 	DescVerbose            = "show step by step information verbosely"
 	DescFixClashes         = "fix clashes by renaming files"
+	DescDescription        = "set the description"
 )
 
 const (
+	CLIOptionDescription        = "description"
 	CLIOptionExplicitlyExport   = "explicitly-export"
 	CLIOptionIgnoreChecksum     = "ignore-checksum"
 	CLIOptionIgnoreConflict     = "ignore-conflict"
@@ -170,6 +177,7 @@ const (
 	CLIOptionWebBrowser         = "web-browser"
 	CLIOptionFileBrowser        = "file-browser"
 	CLIOptionFixClashesKey      = "fix-clashes"
+	CLIOptionPiped              = "piped"
 )
 
 const (
@@ -207,6 +215,9 @@ var docMap = map[string][]string{
 	DiffKey: []string{
 		DescDiff, "Accepts multiple remote paths for line by line comparison",
 		skipChecksumNote,
+	},
+	EditDescriptionShortKey: []string{
+		DescEdit, "Accepts multiple remote paths as well as ids",
 	},
 	EmptyTrashKey: []string{
 		DescEmptyTrash,
@@ -291,10 +302,11 @@ var docMap = map[string][]string{
 
 func createAndRegisterAliases() map[string][]string {
 	aliases := map[string][]string{
-		CopyKey:   []string{"cp"},
-		ListKey:   []string{"ls"},
-		MoveKey:   []string{"mv"},
-		DeleteKey: []string{"del"},
+		CopyKey:            []string{"cp"},
+		ListKey:            []string{"ls"},
+		MoveKey:            []string{"mv"},
+		DeleteKey:          []string{"del"},
+		EditDescriptionKey: []string{EditDescriptionShortKey},
 	}
 
 	for originalKey, aliasList := range aliases {

--- a/src/remote.go
+++ b/src/remote.go
@@ -522,11 +522,7 @@ func (r *Remote) upsertByComparison(body io.Reader, args *upsertOpt) (f *File, m
 	return
 }
 
-func (r *Remote) rename(fileId, newTitle string) (*File, error) {
-	f := &drive.File{
-		Title: newTitle,
-	}
-
+func (r *Remote) byFileIdUpdater(fileId string, f *drive.File) (*File, error) {
 	req := r.service.Files.Update(fileId, f)
 	uploaded, err := req.Do()
 	if err != nil {
@@ -534,6 +530,22 @@ func (r *Remote) rename(fileId, newTitle string) (*File, error) {
 	}
 
 	return NewRemoteFile(uploaded), nil
+}
+
+func (r *Remote) rename(fileId, newTitle string) (*File, error) {
+	f := &drive.File{
+		Title: newTitle,
+	}
+
+	return r.byFileIdUpdater(fileId, f)
+}
+
+func (r *Remote) updateDescription(fileId, newDescription string) (*File, error) {
+	f := &drive.File{
+		Description: newDescription,
+	}
+
+	return r.byFileIdUpdater(fileId, f)
 }
 
 func (r *Remote) removeParent(fileId, parentId string) error {

--- a/src/url.go
+++ b/src/url.go
@@ -22,7 +22,7 @@ func (g *Commands) Url(byId bool) error {
 		case error:
 			g.log.LogErrf("%s: %s\n", kv.key, kv.value)
 		default:
-			g.log.Logf("%s: %s\n", kv.key, kv.value)
+			g.log.Logf("%s: %v\n", kv.key, kv.value)
 		}
 	}
 
@@ -30,27 +30,12 @@ func (g *Commands) Url(byId bool) error {
 }
 
 func (g *Commands) urler(byId bool, sources []string) (kvChan chan *keyValue) {
-	resolver := g.rem.FindByPath
-	if byId {
-		resolver = g.rem.FindById
+	fileUrler := func(f *File) interface{} {
+		if f == nil {
+			return ""
+		}
+		return f.Url()
 	}
 
-	kvChan = make(chan *keyValue)
-
-	go func() {
-		defer close(kvChan)
-
-		for _, source := range sources {
-			f, err := resolver(source)
-
-			kv := keyValue{key: source, value: err}
-			if err == nil {
-				kv.value = f.Url()
-			}
-
-			kvChan <- &kv
-		}
-	}()
-
-	return kvChan
+	return resolver(g, byId, g.opts.Sources, fileUrler)
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/odeke-em/drive/issues/414

You can now run

```shell
$ drive edit-description --description "This summer's photos right here" photos/Ibiza 2015/07/25
$ drive edit-desc --description "This is a description" f1/f2.txt openSrc
$ cat descriptions | drive edit-desc --piped fl/ newestFolders/f1/f2
``` 