### PR TITLE
preview: show previews independent of no-prompt

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -630,10 +630,11 @@ func opChangeCount(changes []*Change) map[Operation]sizeCounter {
 }
 
 type changeListArg struct {
-	logy      *log.Logger
-	changes   []*Change
-	noPrompt  bool
-	noClobber bool
+	logy       *log.Logger
+	changes    []*Change
+	noPrompt   bool
+	noClobber  bool
+	canPreview bool
 }
 
 func previewChanges(clArgs *changeListArg, reduce bool, opMap map[Operation]sizeCounter) {
@@ -663,12 +664,17 @@ func printChangeList(clArg *changeListArg) (bool, *map[Operation]sizeCounter) {
 		clArg.logy.Logln("Everything is up-to-date.")
 		return false, nil
 	}
-	if clArg.noPrompt {
+	if !clArg.canPreview {
 		return true, nil
 	}
 
 	opMap := opChangeCount(clArg.changes)
 	previewChanges(clArg, true, opMap)
 
-	return promptForChanges(), &opMap
+	accepted := clArg.noPrompt
+	if !accepted {
+		accepted = promptForChanges()
+	}
+
+	return accepted, &opMap
 }

--- a/src/commands.go
+++ b/src/commands.go
@@ -110,6 +110,16 @@ func (opts *Options) canPrompt() bool {
 	return !opts.NoPrompt
 }
 
+func (opts *Options) canPreview() bool {
+	if opts == nil || !opts.StdoutIsTty {
+		return false
+	}
+	if opts.Quiet {
+		return false
+	}
+	return true
+}
+
 func rcPathChecker(absDir string) (string, error) {
 	p := rcPath(absDir)
 	statInfo, err := os.Stat(p)

--- a/src/pull.go
+++ b/src/pull.go
@@ -77,10 +77,11 @@ func (g *Commands) Pull(byId bool) error {
 	nonConflicts := *nonConflictsPtr
 
 	clArg := changeListArg{
-		logy:      g.log,
-		changes:   nonConflicts,
-		noPrompt:  !g.opts.canPrompt(),
-		noClobber: g.opts.NoClobber,
+		logy:       g.log,
+		changes:    nonConflicts,
+		noPrompt:   !g.opts.canPrompt(),
+		noClobber:  g.opts.NoClobber,
+		canPreview: g.opts.canPreview(),
 	}
 
 	ok, opMap := printChangeList(&clArg)
@@ -262,10 +263,11 @@ func (g *Commands) PullMatches() (err error) {
 	nonConflicts := *nonConflictsPtr
 
 	clArg := changeListArg{
-		logy:      g.log,
-		changes:   nonConflicts,
-		noPrompt:  !g.opts.canPrompt(),
-		noClobber: g.opts.NoClobber,
+		logy:       g.log,
+		changes:    nonConflicts,
+		noPrompt:   !g.opts.canPrompt(),
+		noClobber:  g.opts.NoClobber,
+		canPreview: g.opts.canPreview(),
 	}
 
 	ok, opMap := printChangeList(&clArg)
@@ -429,7 +431,7 @@ func (g *Commands) playPullChanges(cl []*Change, exports []string, opMap *map[Op
 		}
 	}()
 
-	canPrintSteps := g.opts.Verbose && g.opts.canPrompt()
+	canPrintSteps := g.opts.Verbose && g.opts.canPreview()
 
 	go func() {
 		for ch := range loader {

--- a/src/push.go
+++ b/src/push.go
@@ -140,10 +140,11 @@ func (g *Commands) Push() (err error) {
 	}
 
 	clArg := changeListArg{
-		logy:      g.log,
-		changes:   nonConflicts,
-		noPrompt:  !g.opts.canPrompt(),
-		noClobber: g.opts.NoClobber,
+		logy:       g.log,
+		changes:    nonConflicts,
+		noPrompt:   !g.opts.canPrompt(),
+		noClobber:  g.opts.NoClobber,
+		canPreview: g.opts.canPreview(),
 	}
 
 	ok, opMap := printChangeList(&clArg)
@@ -307,7 +308,7 @@ func (g *Commands) playPushChanges(cl []*Change, opMap *map[Operation]sizeCounte
 	}
 
 	throttle := time.Tick(time.Duration(1e9 / n))
-	canPrintSteps := g.opts.Verbose && g.opts.canPrompt()
+	canPrintSteps := g.opts.Verbose && g.opts.canPreview()
 
 	sort.Sort(ByPrecedence(cl))
 
@@ -451,7 +452,7 @@ func (g *Commands) remoteMod(change *Change) (err error) {
 		dest:           change.Dest,
 		mask:           g.opts.TypeMask,
 		ignoreChecksum: g.opts.IgnoreChecksum,
-		debug:          g.opts.Verbose && g.opts.canPrompt(),
+		debug:          g.opts.Verbose && g.opts.canPreview(),
 	}
 
 	coercedMimeKey, ok := g.coercedMimeKey()
@@ -597,7 +598,7 @@ func (g *Commands) remoteMkdirAll(d string) (file *File, err error) {
 	args := upsertOpt{
 		parentId: parent.Id,
 		src:      remoteFile,
-		debug:    g.opts.Verbose && g.opts.canPrompt(),
+		debug:    g.opts.Verbose && g.opts.canPreview(),
 	}
 
 	cur, curErr := g.rem.UpsertByComparison(&args)


### PR DESCRIPTION
This PR addresses issue https://github.com/odeke-em/drive/issues/300

Previously no-prompt dictated what could be printed during an operation.
However this behaviour was wrong since setting --verbose during a
push/pull yet with --no-prompt would not print out  the manifest.
Also users requested for previews even if no-prompt was set and this is
the correct behaviour.