### PR TITLE
touch: fixed up premature force exit on nil elem

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -215,6 +215,8 @@ func reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination bool) c
 	throttle := time.Tick(1e7)
 
 	go func() {
+		defer close(fileChan)
+
 		pageToken := ""
 		for {
 			if pageToken != "" {
@@ -249,9 +251,8 @@ func reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination bool) c
 				break
 			}
 		}
-
-		close(fileChan)
 	}()
+
 	return fileChan
 }
 


### PR DESCRIPTION
This PR addresses issue #442 by fixing up a bug in which while multiplexing over
the channels and looking for channels that had been drained,
legacy select code still had a forced `nil` emission at a deferred
statement. However, once a channel has been drained, any attempt to
read from it will also return `nil`. Coupling this knowledge with
a recursive traversal of children, `nil` was being added prematurely.
It also refactors the code used by the plain Touch and TouchByMatch
.

#### Before
```shell
$ drive touch --recursive
/ENGINEERING/Fall2015/BLAW_301: 2015-10-26 02:06:21 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt: 2015-10-26 02:06:22 +0000 UTC
$ drive list
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch02.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch03.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch04.ppt 
/ENGINEERING/Fall2015/BLAW_301/commencing-a-claim-in-provincial-court-civil-and-getting-and-enforcing-your-judgment-in-alberta.pdf 
/ENGINEERING/Fall2015/BLAW_301/BLaw-301--Mon14Sept2015P1.pdf 
/ENGINEERING/Fall2015/BLAW_301/Chapter 2 Asha and Shaughnessy (to post).ppt 
/ENGINEERING/Fall2015/BLAW_301/manny-pacquaio-lawsuit.pdf 
$ drive touch --recursive
/ENGINEERING/Fall2015/BLAW_301: 2015-10-26 02:07:07 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt: 2015-10-26 02:07:08 +0000 UTC
$ drive touch --recursive
/ENGINEERING/Fall2015/BLAW_301: 2015-10-26 02:07:10 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt: 2015-10-26 02:07:12 +0000 UTC
```

#### After
```shell
$ drive touch --recursive
/ENGINEERING/Fall2015/BLAW_301: 2015-10-26 02:13:26 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt: 2015-10-26 02:13:27 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch02.ppt: 2015-10-26 02:13:29 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch03.ppt: 2015-10-26 02:13:31 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/ch04.ppt: 2015-10-26 02:13:33 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/commencing-a-claim-in-provincial-court-civil-and-getting-and-enforcing-your-judgment-in-alberta.pdf: 2015-10-26 02:13:35 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/BLaw-301--Mon14Sept2015P1.pdf: 2015-10-26 02:13:37 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/Chapter 2 Asha and Shaughnessy (to post).ppt: 2015-10-26 02:13:39 +0000 UTC
/ENGINEERING/Fall2015/BLAW_301/manny-pacquaio-lawsuit.pdf: 2015-10-26 02:13:41 +0000 UTC
$ drive list
/ENGINEERING/Fall2015/BLAW_301/manny-pacquaio-lawsuit.pdf 
/ENGINEERING/Fall2015/BLAW_301/Chapter 2 Asha and Shaughnessy (to post).ppt 
/ENGINEERING/Fall2015/BLAW_301/BLaw-301--Mon14Sept2015P1.pdf 
/ENGINEERING/Fall2015/BLAW_301/commencing-a-claim-in-provincial-court-civil-and-getting-and-enforcing-your-judgment-in-alberta.pdf 
/ENGINEERING/Fall2015/BLAW_301/ch04.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch03.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch02.ppt 
/ENGINEERING/Fall2015/BLAW_301/ch01.ppt 
```