### PR TITLE
pull/push: pass in Hidden

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -320,6 +320,7 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 		fslArg := fsListingArg{
 			parent:  base,
 			context: g.context,
+			hidden:  g.opts.Hidden,
 			depth:   traversalDepth,
 			ignore:  g.opts.IgnoreRegexp,
 		}


### PR DESCRIPTION
This PR fixes issue #444 
Fixes a regression bug in which hidden wasn't being passed into
an fsListingArg item before a local listing.