### PR TITLE
delete: link user to no-prompt discussion

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1088,10 +1088,11 @@ func (cmd *emptyTrashCmd) Run(args []string, definedFlags map[string]*flag.Flag)
 }
 
 type deleteCmd struct {
-	Hidden  *bool `json:"hidden"`
-	Matches *bool `json:"matches"`
-	Quiet   *bool `json:"quiet"`
-	ById    *bool `json:"by-id"`
+	Hidden   *bool `json:"hidden"`
+	Matches  *bool `json:"matches"`
+	Quiet    *bool `json:"quiet"`
+	ById     *bool `json:"by-id"`
+	NoPrompt *bool `json:"no-prompt"`
 }
 
 func (cmd *deleteCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1099,11 +1100,16 @@ func (cmd *deleteCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Matches = fs.Bool(drive.MatchesKey, false, "search by prefix and delete")
 	cmd.Quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.ById = fs.Bool(drive.CLIOptionId, false, "delete by id instead of path")
+	cmd.NoPrompt = fs.Bool(drive.NoPromptKey, false, "disables the prompt")
 
 	return fs
 }
 
 func (cmd *deleteCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
+	if *cmd.NoPrompt {
+		exitWithError(drive.PermanentDeletionNoPromptError)
+	}
+
 	sources, context, path := preprocessArgsByToggle(args, *cmd.Matches || *cmd.ById)
 
 	opts := drive.Options{

--- a/src/help.go
+++ b/src/help.go
@@ -219,8 +219,11 @@ const (
 	InfiniteDepth = -1
 )
 
-var skipChecksumNote = fmt.Sprintf(
-	"\nNote: You can skip checksum verification by passing in flag `-%s`", CLIOptionIgnoreChecksum)
+var (
+	skipChecksumNote = fmt.Sprintf(
+		"\nNote: You can skip checksum verification by passing in flag `-%s`", CLIOptionIgnoreChecksum)
+	PermanentDeletionNoPromptError = fmt.Errorf("%q is set yet performing a permanent deletion. Please see issue https://github.com/odeke-em/drive/issues/448", NoPromptKey)
+)
 
 var docMap = map[string][]string{
 	AboutKey: []string{


### PR DESCRIPTION
This PR links a user to the discussion on why we don't enable `--no-prompt` as the contents of discussion #448.

#### Before
```shell
$ drive delete --no-prompt fox
flag provided but not defined: -no-prompt
Usage of delete:
  -h	
  -hidden
    	allows trashing hidden paths
  -id
    	delete by id instead of path
  -matches
    	search by prefix and delete
  -quiet
    	if set, do not log anything but errors
```

#### After
```shell
$ drive delete --no-prompt fox

"no-prompt" is set yet performing a permanent deletion. Please see issue https://github.com/odeke-em/drive/issues/448
```