### PR TITLE
mounted-push: contextAbsPath joined from root

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -911,6 +911,7 @@ func (pCmd *pushCmd) createPushOptions(absEntryPath string, definedFlags map[str
 func (cmd *pushCmd) pushMounted(args []string, definedFlags map[string]*flag.Flag) {
 	argc := len(args)
 
+	var err error
 	var contextArgs, rest, sources []string
 
 	if !*cmd.MountedPush {
@@ -932,16 +933,14 @@ func (cmd *pushCmd) pushMounted(args []string, definedFlags map[string]*flag.Fla
 	rest = drive.NonEmptyStrings(rest...)
 	context, path := discoverContext(contextArgs)
 
-	contextAbsPath, err := filepath.Abs(path)
-	exitWithError(err)
-
 	if path == "." {
 		path = ""
 	}
 
-	mount, auxSrcs := config.MountPoints(path, contextAbsPath, rest, *cmd.Hidden)
-
 	root := context.AbsPathOf("")
+	contextAbsPath := filepath.Join(root, path)
+
+	mount, auxSrcs := config.MountPoints(path, contextAbsPath, rest, *cmd.Hidden)
 
 	sources, err = relativePathsOpt(root, auxSrcs, true)
 	exitWithError(err)


### PR DESCRIPTION
This PR addresses #451 

Previously the contextAbsPath was erraneously gotten by a
filepath.Abs(path) operation. However this is wrong and only
works when running from the root folder. The correct way is
to filepath.Join(root, path)