### PR TITLE
qr-share: use default credentials plus global app

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -786,7 +786,7 @@ type qrLinkCmd struct {
 }
 
 func (cmd *qrLinkCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
-	cmd.Address = fs.String(drive.AddressKey, "http://localhost:3000", "address on which the QR code generator is running")
+	cmd.Address = fs.String(drive.AddressKey, drive.DefaultQRShareServer, "address on which the QR code generator is running")
 	cmd.ById = fs.Bool(drive.CLIOptionId, false, "share by id instead of path")
 	cmd.Verbose = fs.Bool(drive.CLIOptionVerboseKey, true, drive.DescVerbose)
 	return fs

--- a/src/qr-share.go
+++ b/src/qr-share.go
@@ -30,13 +30,17 @@ var envKeyAlias = &extractor.EnvKey{
 	PrivKeyAlias: "DRIVE_SERVER_PRIV_KEY",
 }
 
+const (
+	DefaultQRShareServer = "https://qr-server.herokuapp.com/drive"
+)
+
 var envKeySet = extractor.KeySetFromEnv(envKeyAlias)
 
 func (g *Commands) QR(byId bool) error {
 
 	kvChan := g.urler(byId, g.opts.Sources)
 
-	address := "http://localhost:3000"
+	address := DefaultQRShareServer
 	if g.opts.Meta != nil {
 		meta := *(g.opts.Meta)
 		if retrAddress, ok := meta[AddressKey]; ok && len(retrAddress) >= 1 {
@@ -45,6 +49,12 @@ func (g *Commands) QR(byId bool) error {
 	}
 
 	address = strings.TrimRight(address, "/")
+	if envKeySet.PublicKey == "" {
+		envKeySet.PublicKey = "5160897b3586461e83e7279c10352ac4"
+	}
+	if envKeySet.PrivateKey == "" {
+		envKeySet.PrivateKey = "5a3451dadab74f75b16f754c0a931949"
+	}
 
 	for kv := range kvChan {
 		switch kv.value.(type) {


### PR DESCRIPTION
This PR addresses issue https://github.com/odeke-em/drive/issues/453