### PR TITLE
pull-all-starred

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Pulling starred files is allowed as well
 ```shell
 $ drive pull --starred
 $ drive pull --starred --matches content
+$ drive pull --starred --all # Pull all the starred files
 ```
 
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -624,12 +624,14 @@ type pullCmd struct {
 	ExplicitlyExport  *bool   `json:"explicitly-export"`
 	FixClashes        *bool   `json:"fix-clashes"`
 
-	Verbose *bool `json:"verbose"`
-	Depth   *int  `json:"depth"`
-	Starred *bool `json:"starred"`
+	Verbose    *bool `json:"verbose"`
+	Depth      *int  `json:"depth"`
+	Starred    *bool `json:"starred"`
+	AllStarred *bool `json:"all-starred"`
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
+	cmd.AllStarred = fs.Bool(drive.CLIOptionAllStarred, false, drive.DescAllStarred)
 	cmd.NoClobber = fs.Bool(drive.CLIOptionNoClobber, false, "prevents overwriting of old content")
 	cmd.Export = fs.String(
 		drive.ExportsKey, "", "comma separated list of formats to export your docs + sheets files")
@@ -708,7 +710,11 @@ func (pCmd *pullCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	}
 
 	if *cmd.Matches || *cmd.Starred {
-		exitWithError(drive.New(context, options).PullMatchLike())
+		if *cmd.AllStarred {
+			exitWithError(drive.New(context, options).PullAllStarred())
+		} else {
+			exitWithError(drive.New(context, options).PullMatchLike())
+		}
 	} else if *cmd.Piped {
 		exitWithError(drive.New(context, options).PullPiped(*cmd.ById))
 	} else if *cmd.ById {

--- a/src/help.go
+++ b/src/help.go
@@ -115,6 +115,7 @@ const (
 const (
 	DescAbout                 = "print out information about your Google drive"
 	DescAll                   = "print out the entire help section"
+	DescAllStarred            = "all the starred files"
 	DescCopy                  = "copy remote paths to a destination"
 	DescDelete                = "deletes the items permanently. This operation is irreversible"
 	DescDiff                  = "compares local files with their remote equivalent"
@@ -204,6 +205,7 @@ const (
 	CLIOptionFixClashesKey      = "fix-clashes"
 	CLIOptionPiped              = "piped"
 	CLIOptionStarred            = "starred"
+	CLIOptionAllStarred         = "all"
 )
 
 const (


### PR DESCRIPTION
This PR finishes up and introduces the ability to pull all starred files finishing up https://github.com/odeke-em/drive/issues/431
Retraces full path given the fileId hences aids
in pull all the starred files

```shell
$ drive pull --all --starred
```