### PR TITLE
ignore dir modTimes

### DIFF
--- a/src/types.go
+++ b/src/types.go
@@ -447,8 +447,14 @@ func (c *Change) op() Operation {
 	if c.Src.IsDir != c.Dest.IsDir {
 		return indexExistanceOrDeferTo(c, OpMod, indexingOnly)
 	}
+
 	if c.Src.IsDir {
-		if fileModTimesDiffer(c.Src, c.Dest) {
+		// In regards to https://github.com/odeke-em/drive/issues/477
+		// local dir modTimes get spuriously changed by ordinary shell
+		// operations on the children.
+		// When the time is right to actually compare these times
+		// without irking users, allow modTime checks
+		if false && fileModTimesDiffer(c.Src, c.Dest) {
 			return OpMod
 		}
 		return indexExistanceOrDeferTo(c, OpNone, indexingOnly)


### PR DESCRIPTION
This PR addresses https://github.com/odeke-em/drive/issues/477.

directories get spurious modTime changes from ordinary mutating
shell operations on their children e.g rm, touch, mv etc.

Allowing for dirs to have accurate modTimes risks creating bad
user experience for which actually the user shouldn't have to worry
about and the previous change introducing this behaviour was just
being strict.