### PR TITLE
rc: fix premature string array conversion

### DIFF
--- a/src/rc.go
+++ b/src/rc.go
@@ -103,11 +103,12 @@ func parseRCValues(rcMap map[string]string) (valueMappings map[string]interface{
 		{
 			resolver: _stringfer, keys: []string{
 				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
+				ExportsKey, ExcludeOpsKey,
 			},
 		},
 		{
 			resolver: _stringArrayfer, keys: []string{
-				ExportsKey, ExcludeOpsKey,
+			// Add items that might need string array parsing and conversion here
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes issue #488 

CSV values get parsed in the cmd/drive/main.go command after
they've already been parsed from the RC. The remedy here
is to pass back such values as they are to be handled appropriately.