### PR TITLE
diff: unified diff option added

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1032,6 +1032,7 @@ type diffCmd struct {
 	Quiet             *bool `json:"quiet"`
 	Depth             *int  `json:"depth"`
 	Recursive         *bool `json:"recursive"`
+	Unified           *bool `json:"unified"`
 }
 
 func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1042,12 +1043,18 @@ func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.Depth = fs.Int(drive.DepthKey, drive.DefaultMaxTraversalDepth, "max traversal depth")
 	cmd.Recursive = fs.Bool(drive.RecursiveKey, true, "recursively diff")
+	cmd.Unified = fs.Bool(drive.CLIOptionUnifiedShortKey, true, drive.DescUnifiedDiff)
 
 	return fs
 }
 
 func (cmd *diffCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	sources, context, path := preprocessArgs(args)
+
+	mask := drive.DiffNone
+	if *cmd.Unified {
+		mask |= drive.DiffUnified
+	}
 
 	exitWithError(drive.New(context, &drive.Options{
 		Path:              path,
@@ -1059,6 +1066,7 @@ func (cmd *diffCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		IgnoreConflict:    *cmd.IgnoreConflict,
 		Quiet:             *cmd.Quiet,
 		Depth:             *cmd.Depth,
+		TypeMask:          mask,
 	}).Diff())
 }
 

--- a/src/help.go
+++ b/src/help.go
@@ -174,6 +174,7 @@ const (
 	DescDescription        = "set the description"
 	DescQR                 = "open up the QR code for specified files"
 	DescStarred            = "operate only on starred files"
+	DescUnifiedDiff        = "unified diff"
 )
 
 const (
@@ -207,6 +208,8 @@ const (
 	CLIOptionPiped              = "piped"
 	CLIOptionStarred            = "starred"
 	CLIOptionAllStarred         = "all"
+	CLIOptionUnified            = "unified"
+	CLIOptionUnifiedShortKey    = "u"
 )
 
 const (

--- a/src/rc.go
+++ b/src/rc.go
@@ -103,7 +103,7 @@ func parseRCValues(rcMap map[string]string) (valueMappings map[string]interface{
 		{
 			resolver: _stringfer, keys: []string{
 				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
-				ExportsKey, ExcludeOpsKey,
+				ExportsKey, ExcludeOpsKey, CLIOptionUnifiedShortKey, CLIOptionUnified,
 			},
 		},
 		{


### PR DESCRIPTION
This PR addresses #494 and provides a unified diff option ie
```shell
$ drive diff -u [paths...]
```
by default `-u` is set to true therefore to turn it off

```shell
$ drive diff -u false [paths...]
$ drive diff -u=false [paths...]
```

## Samples

#### Unified diff
```shell
$ drive diff ls.txt 
File: /diff-test/ls.txt
* local:          2015-11-26T17:32:49.000Z                
* remote:         2015-11-26T17:32:09.000Z                
ls.txt
****

--- /Users/emmanuelodeke/emm.odeke@gmail.com/diff-test/ls.txt	2015-11-26 10:32:49.000000000 -0700
+++ .xtmp5577006791947779410.tmp666634729	2015-11-26 10:33:03.000000000 -0700
@@ -1,6 +1,15 @@
-LICENSE
-README.md
-cache.go
-cache_test.go
-exports.go
-swift
+02 Downtown (feat. Kidd Kidd).m4a
+About_A_Girl.mp3
+drop.avi
+sample.3gp
+sample.m4a
+sample.midi
+sample.wav
+sample_3GPP2.3g2
+sample_iPod.m4v
+sample_iTunes.mov
+sample_mpeg2.m2v
+sample_mpeg4.mp4
+violin07.aif
+violin12.aif
+zips
```

#### Not unified
```shell
$ drive diff -u=false ls.txt 
File: /diff-test/ls.txt
* local:          2015-11-26T17:32:49.000Z                
* remote:         2015-11-26T17:32:09.000Z                
ls.txt
****

1,6c1,15
< LICENSE
< README.md
< cache.go
< cache_test.go
< exports.go
< swift
---
> 02 Downtown (feat. Kidd Kidd).m4a
> About_A_Girl.mp3
> drop.avi
> sample.3gp
> sample.m4a
> sample.midi
> sample.wav
> sample_3GPP2.3g2
> sample_iPod.m4v
> sample_iTunes.mov
> sample_mpeg2.m2v
> sample_mpeg4.mp4
> violin07.aif
> violin12.aif
> zips
```