### PR TITLE
fixed docs vs docx regex clash

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -499,10 +499,11 @@ var regExtStrMap = map[string]string{
 
 	"mp3": "audio/mpeg",
 
-	"docx?": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"pptx?": "application/vnd.ms-powerpoint",
-	"tsv":   "text/tab-separated-values",
-	"xlsx?": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	// docs and docx should not collide if "docx?" is used so terminate with "$"
+	"docx?$": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	"pptx?":   "application/vnd.ms-powerpoint",
+	"tsv":     "text/tab-separated-values",
+	"xlsx?":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }
 
 func regMapper(srcMaps ...map[string]string) map[*regexp.Regexp]string {


### PR DESCRIPTION
This PR fixes issue #500 and deterministically distinguishes between docs and docx files.