### PR TITLE
diff: allow base switching between local or remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,13 @@ You can diff to a desired depth
 $ drive diff --depth 2 sub-folders/ contacts/ listings.txt
 ```
 
+You can also switch the base, either local or remote by using flag `--base-local`
+
+```shell
+$ drive diff --base-local=true assignments photos # To use local as the base
+$ drive diff --base-local=false infocom photos # To use remote as the base
+```
+
 
 ### Touching
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1033,6 +1033,7 @@ type diffCmd struct {
 	Depth             *int  `json:"depth"`
 	Recursive         *bool `json:"recursive"`
 	Unified           *bool `json:"unified"`
+	BaseLocal         *bool `json:"base-local"`
 }
 
 func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1044,6 +1045,7 @@ func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Depth = fs.Int(drive.DepthKey, drive.DefaultMaxTraversalDepth, "max traversal depth")
 	cmd.Recursive = fs.Bool(drive.RecursiveKey, true, "recursively diff")
 	cmd.Unified = fs.Bool(drive.CLIOptionUnifiedShortKey, true, drive.DescUnifiedDiff)
+	cmd.BaseLocal = fs.Bool(drive.CLIOptionDiffBaseLocal, true, drive.DescDiffBaseLocal)
 
 	return fs
 }
@@ -1066,6 +1068,7 @@ func (cmd *diffCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		IgnoreConflict:    *cmd.IgnoreConflict,
 		Quiet:             *cmd.Quiet,
 		Depth:             *cmd.Depth,
+		BaseLocal:         *cmd.BaseLocal,
 		TypeMask:          mask,
 	}).Diff())
 }

--- a/src/commands.go
+++ b/src/commands.go
@@ -89,6 +89,9 @@ type Options struct {
 	FixClashes        bool
 	Match             bool
 	Starred           bool
+	// BaseLocal when set, during a diff uses the local file
+	// as the base otherwise remote is used as the base
+	BaseLocal bool
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -175,6 +175,7 @@ const (
 	DescQR                 = "open up the QR code for specified files"
 	DescStarred            = "operate only on starred files"
 	DescUnifiedDiff        = "unified diff"
+	DescDiffBaseLocal      = "when set uses local as the base other remote will be used as the base"
 )
 
 const (
@@ -211,6 +212,7 @@ const (
 	CLIOptionAllStarred         = "all"
 	CLIOptionUnified            = "unified"
 	CLIOptionUnifiedShortKey    = "u"
+	CLIOptionDiffBaseLocal      = "base-local"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -501,9 +501,9 @@ var regExtStrMap = map[string]string{
 
 	// docs and docx should not collide if "docx?" is used so terminate with "$"
 	"docx?$": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"pptx?":   "application/vnd.ms-powerpoint",
-	"tsv":     "text/tab-separated-values",
-	"xlsx?":   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	"pptx?":  "application/vnd.ms-powerpoint",
+	"tsv":    "text/tab-separated-values",
+	"xlsx?":  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }
 
 func regMapper(srcMaps ...map[string]string) map[*regexp.Regexp]string {

--- a/src/rc.go
+++ b/src/rc.go
@@ -102,8 +102,9 @@ func parseRCValues(rcMap map[string]string) (valueMappings map[string]interface{
 		},
 		{
 			resolver: _stringfer, keys: []string{
+				CLIOptionUnified, CLIOptionDiffBaseLocal,
+				ExportsKey, ExcludeOpsKey, CLIOptionUnifiedShortKey,
 				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
-				ExportsKey, ExcludeOpsKey, CLIOptionUnifiedShortKey, CLIOptionUnified,
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #506

Allows users to switch decide if local
is the base otherwise use remote.

### remote as the base, local as the other
```shell
$ drive diff --base-local=false ls.txt 
File: /diff-test/ls.txt
* local:          2015-11-26T17:32:49.000Z                
* remote:         2015-11-26T17:32:09.000Z                
ls.txt
****

--- .xtmp5577006791947779410.tmp537523880	2015-11-29 20:11:18.000000000 -0700
+++ /Users/emmanuelodeke/emm.odeke@gmail.com/diff-test/ls.txt	2015-11-26 10:32:49.000000000 -0700
@@ -1,15 +1,6 @@
-02 Downtown (feat. Kidd Kidd).m4a
-About_A_Girl.mp3
-drop.avi
-sample.3gp
-sample.m4a
-sample.midi
-sample.wav
-sample_3GPP2.3g2
-sample_iPod.m4v
-sample_iTunes.mov
-sample_mpeg2.m2v
-sample_mpeg4.mp4
-violin07.aif
-violin12.aif
-zips
+LICENSE
+README.md
+cache.go
+cache_test.go
+exports.go
+swift
```

### local as the base, remote as the other
```shell
$ drive diff --base-local ls.txt 
File: /diff-test/ls.txt
* local:          2015-11-26T17:32:49.000Z                
* remote:         2015-11-26T17:32:09.000Z                
ls.txt
****

--- /Users/emmanuelodeke/emm.odeke@gmail.com/diff-test/ls.txt	2015-11-26 10:32:49.000000000 -0700
+++ .xtmp5577006791947779410.tmp658721850	2015-11-29 20:11:22.000000000 -0700
@@ -1,6 +1,15 @@
-LICENSE
-README.md
-cache.go
-cache_test.go
-exports.go
-swift
+02 Downtown (feat. Kidd Kidd).m4a
+About_A_Girl.mp3
+drop.avi
+sample.3gp
+sample.m4a
+sample.midi
+sample.wav
+sample_3GPP2.3g2
+sample_iPod.m4v
+sample_iTunes.mov
+sample_mpeg2.m2v
+sample_mpeg4.mp4
+violin07.aif
+violin12.aif
+zips
```