### PR TITLE
pull: export exportables on mod without checksum

### DIFF
--- a/src/pull.go
+++ b/src/pull.go
@@ -578,7 +578,11 @@ func (g *Commands) localMod(change *Change, exports []string) (err error) {
 	// Simple heuristic to avoid downloading all the
 	// content yet it could just be a modTime difference
 	mask := fileDifferences(change.Src, change.Dest, change.IgnoreChecksum)
-	if checksumDiffers(mask) && !change.Dest.IsDir {
+
+	needsDownload := checksumDiffers(mask) && !change.Dest.IsDir
+	exportsRequested := len(exports) >= 1 && hasExportLinks(change.Src)
+
+	if needsDownload || exportsRequested {
 		// download and replace
 		if err = g.download(change, exports); err != nil {
 			return


### PR DESCRIPTION
Fixes #496.

Now allows for docs to be exported when modified since before
there was a clause that prevented files from being downloaded
if their checksums varied, of which exportable docs have no
raw content hence their checksums will always be the same
yet this is registered as only a ModTime change.