### PR TITLE
pull/starred: separate trashed and untrashed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ Pulling starred files is allowed as well
 ```shell
 $ drive pull --starred
 $ drive pull --starred --matches content
-$ drive pull --starred --all # Pull all the starred files
+$ drive pull --starred --all # Pull all the starred files that aren't in the trash
+$ drive pull --starred --all --trashed # Pull all the starred files in the trash
 ```
 
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -302,7 +302,7 @@ type listCmd struct {
 	LongFmt      *bool   `json:"long"`
 	NoPrompt     *bool   `json:"no-prompt"`
 	Shared       *bool   `json:"shared"`
-	InTrash      *bool   `json:"in-trash"`
+	InTrash      *bool   `json:"trashed"`
 	Version      *bool   `json:"version"`
 	Matches      *bool   `json:"matches"`
 	Owners       *bool   `json:"owners"`
@@ -628,6 +628,7 @@ type pullCmd struct {
 	Depth      *int  `json:"depth"`
 	Starred    *bool `json:"starred"`
 	AllStarred *bool `json:"all-starred"`
+	InTrash    *bool `json:"trashed"`
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -654,6 +655,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Depth = fs.Int(drive.DepthKey, drive.DefaultMaxTraversalDepth, "max traversal depth")
 	cmd.FixClashes = fs.Bool(drive.CLIOptionFixClashesKey, false, drive.DescFixClashes)
 	cmd.Starred = fs.Bool(drive.CLIOptionStarred, false, drive.DescStarred)
+	cmd.InTrash = fs.Bool(drive.TrashedKey, false, "pull content in the trash")
 
 	return fs
 }
@@ -707,6 +709,7 @@ func (pCmd *pullCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		FixClashes:        *cmd.FixClashes,
 		Starred:           *cmd.Starred,
 		Match:             *cmd.Matches,
+		InTrash:           *cmd.InTrash,
 	}
 
 	if *cmd.Matches || *cmd.Starred {

--- a/src/pull.go
+++ b/src/pull.go
@@ -213,6 +213,7 @@ func typeByAllStarred(pt pullType) bool {
 }
 
 func pullLikeResolve(g *Commands, pt pullType) (cl, clashes []*Change, err error) {
+	// TODO: (@odeke-em) allow pull-trashed
 	g.log.Logln("Resolving...")
 
 	spin := g.playabler()
@@ -251,7 +252,7 @@ func matchQuerier(g *Commands, pt pullType) *matchQuery {
 }
 
 func (g *Commands) pullAllStarred() (cl, clashes []*Change, err error) {
-	starredFilesChan, sErr := g.rem.FindStarred()
+	starredFilesChan, sErr := g.rem.FindStarred(g.opts.InTrash, g.opts.Hidden)
 	if sErr != nil {
 		err = sErr
 		return
@@ -343,6 +344,8 @@ func (g *Commands) PullPiped(byId bool) (err error) {
 	if byId {
 		resolver = g.rem.FindById
 	}
+
+	// TODO: (@odeke-em) allow pull-trashed
 
 	for _, relToRootPath := range g.opts.Sources {
 		rem, err := resolver(relToRootPath)

--- a/src/remote.go
+++ b/src/remote.go
@@ -836,11 +836,11 @@ func (r *Remote) FindByPathShared(p string) (chan *File, error) {
 	return r.findShared(nonEmpty)
 }
 
-func (r *Remote) FindStarred() (chan *File, error) {
+func (r *Remote) FindStarred(trashed, hidden bool) (chan *File, error) {
 	req := r.service.Files.List()
-	expr := "(starred=true)"
+	expr := fmt.Sprintf("(starred=true) and (trashed=%v)", trashed)
 	req.Q(expr)
-	return reqDoPage(req, true, false), nil
+	return reqDoPage(req, hidden, false), nil
 }
 
 func (r *Remote) FindMatches(mq *matchQuery) (chan *File, error) {


### PR DESCRIPTION
Fixes #515.

This PR allows for a user to distinguish between
trashed and untrashed starred files.