### PR TITLE
new: define a custom logger if opts==nil

### DIFF
--- a/src/commands.go
+++ b/src/commands.go
@@ -170,7 +170,9 @@ func New(context *config.Context, opts *Options) *Commands {
 
 	var logger *log.Logger = nil
 
-	if opts != nil {
+	if opts == nil {
+		logger = log.New(stdin, stdout, stderr)
+	} else {
 		if opts.Quiet {
 			stdout = nil
 		}
@@ -198,10 +200,6 @@ func New(context *config.Context, opts *Options) *Commands {
 
 			opts.IgnoreRegexp = ignoreRegexp
 		}
-	}
-
-	if logger == nil {
-		panic("logger cannot be nil")
 	}
 
 	return &Commands{


### PR DESCRIPTION
Fixes #524.

For commands such as `init`, the opts are nil so use
the vanilla logger for such cases and don't panic.