### PR TITLE
find*Multi version to find all clashes and matches

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -47,6 +47,7 @@ var (
 const (
 	MimeTypeJoiner      = "-"
 	RemoteDriveRootPath = "My Drive"
+	RemoteSeparator     = "/"
 
 	FmtTimeString           = "2006-01-02T15:04:05.000Z"
 	MsgClashesFixedNowRetry = "Clashes were fixed, please retry the operation"


### PR DESCRIPTION
This PR gives the ability for multiple matches to be returned as opposed to the old style that assumed that only the head would be needed. It is essential to return and explore/traverse all potential matches. This helps fix issues like https://github.com/odeke-em/drive/issues/317 and it is better + cleaner version of PR https://github.com/odeke-em/drive/pull/356.

This PR also ensures that all clashes are reported too during a diff, pull and push.