### PR TITLE
added a clashes command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
   - [Help](#help)
   - [Move](#move)
   - [Rename](#rename)
+  - [Clashes](#clashes)
   - [DriveIgnore](#driveignore)
   - [DriveRC](#driverc)
   - [DesktopEntry](#desktopentry)
@@ -847,6 +848,22 @@ $ drive rename openSrc/2015 2015-Contributions
 $ drive rename 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 fluxing
 ```
 
+### Clashes
+
+You can deal with clashes by using command `drive clashes`.
+
+* To list clashes, you can do
+
+```shell
+$ drive clashes [paths...]
+$ drive clashes --list [paths...] # To be more explicit
+```
+
+* To fix clashes, you can do:
+
+```
+$ drive clashes --fix [paths...]
+```
 
 ### Move
 

--- a/src/clashes.go
+++ b/src/clashes.go
@@ -1,0 +1,234 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func (g *Commands) ListClashes(byId bool) error {
+	clashes, err := listClashes(g, g.opts.Sources, byId)
+	if len(clashes) < 1 {
+		if err == nil {
+			return fmt.Errorf("no clashes exist!")
+		} else {
+			return err
+		}
+	}
+
+	if err != nil && err != ErrClashesDetected {
+		return err
+	}
+
+	warnClashesPersist(g.log, clashes)
+	return nil
+}
+
+func (g *Commands) FixClashes(byId bool) error {
+	clashes, err := listClashes(g, g.opts.Sources, byId)
+
+	if len(clashes) < 1 {
+		return err
+	}
+
+	if err != nil && err != ErrClashesDetected {
+		return err
+	}
+
+	return autoRenameClashes(g, clashes)
+}
+
+func findClashesForChildren(g *Commands, parentId, relToRootPath string, depth int) (clashes []*Change, err error) {
+	if depth == 0 {
+		return
+	}
+
+	memoized := map[string][]*File{}
+	children := g.rem.FindByParentId(parentId, g.opts.Hidden)
+	decrementedDepth := decrementTraversalDepth(depth)
+
+	discoveryOrder := []string{}
+	for child := range children {
+		if child == nil {
+			continue
+		}
+		cluster, alreadyDiscovered := memoized[child.Name]
+		if !alreadyDiscovered {
+			discoveryOrder = append(discoveryOrder, child.Name)
+		}
+
+		cluster = append(cluster, child)
+		memoized[child.Name] = cluster
+	}
+
+	// To preserve the discovery order
+	for _, commonKey := range discoveryOrder {
+		cluster, _ := memoized[commonKey]
+		fullRelToRootPath := sepJoin(RemoteSeparator, relToRootPath, commonKey)
+		nameClashesPresent := len(cluster) > 1
+
+		for _, rem := range cluster {
+			if nameClashesPresent {
+				change := &Change{
+					Src: rem, g: g,
+					Path:   fullRelToRootPath,
+					Parent: g.opts.Path,
+				}
+
+				clashes = append(clashes, change)
+			}
+
+			ccl, cErr := findClashesForChildren(g, rem.Id, fullRelToRootPath, decrementedDepth)
+			clashes = append(clashes, ccl...)
+			if cErr != nil {
+				err = reComposeError(err, cErr.Error())
+			}
+		}
+	}
+
+	return
+}
+
+func findClashesByPath(g *Commands, relToRootPath string, depth int) (clashes []*Change, err error) {
+	if depth == 0 {
+		return
+	}
+
+	remotes := g.rem.FindByPathM(relToRootPath)
+
+	iterCount := uint64(0)
+	clashThresholdCount := uint64(1)
+
+	cl := []*Change{}
+
+	for rem := range remotes {
+		if rem == nil {
+			continue
+		}
+
+		iterCount++
+
+		change := &Change{
+			Src: rem, g: g,
+			Path:   relToRootPath,
+			Parent: g.opts.Path,
+		}
+
+		cl = append(cl, change)
+	}
+
+	if iterCount > clashThresholdCount {
+		clashes = append(clashes, cl...)
+	}
+
+	decrementedDepth := decrementTraversalDepth(depth)
+	if decrementedDepth == 0 {
+		return
+	}
+
+	for _, change := range cl {
+		ccl, cErr := findClashesForChildren(g, change.Src.Id, change.Path, decrementedDepth)
+		if cErr != nil {
+			err = reComposeError(err, cErr.Error())
+		}
+
+		clashes = append(clashes, ccl...)
+	}
+
+	return
+}
+
+func listClashes(g *Commands, sources []string, byId bool) (clashes []*Change, err error) {
+	for _, relToRootPath := range g.opts.Sources {
+		cclashes, cErr := findClashesByPath(g, relToRootPath, g.opts.Depth)
+
+		clashes = append(clashes, cclashes...)
+
+		if cErr != nil {
+			err = reComposeError(err, cErr.Error())
+		}
+	}
+
+	return
+}
+
+func autoRenameClashes(g *Commands, clashes []*Change) error {
+	clashesMap := map[string][]*Change{}
+
+	for _, clash := range clashes {
+		group := clashesMap[clash.Path]
+		if clash.Src == nil {
+			continue
+		}
+		clashesMap[clash.Path] = append(group, clash)
+	}
+
+	renames := make([]renameOp, 0, len(clashesMap)) // we will have at least len(clashesMap) renames
+
+	for commonPath, group := range clashesMap {
+		ext := filepath.Ext(commonPath)
+		name := strings.TrimSuffix(commonPath, ext)
+		nextIndex := 0
+
+		for i, n := 1, len(group); i < n; i++ { // we can leave first item with original name
+			var newName string
+			for {
+				newName = fmt.Sprintf("%v_%d%v", name, nextIndex, ext)
+				nextIndex++
+
+				dupCheck, err := g.rem.FindByPath(newName)
+				if err != nil && err != ErrPathNotExists {
+					return err
+				}
+
+				if dupCheck == nil {
+					newName = filepath.Base(newName)
+					break
+				}
+			}
+
+			r := renameOp{newName: newName, change: group[i], originalPath: commonPath}
+			renames = append(renames, r)
+		}
+	}
+
+	if g.opts.canPrompt() {
+		g.log.Logln("Some clashes found, we can fix them by following renames:")
+		for _, r := range renames {
+			g.log.Logf("%v %v -> %v\n", r.originalPath, r.change.Src.Id, r.newName)
+		}
+		status := promptForChanges("Proceed with the changes [Y/N] ? ")
+		if !accepted(status) {
+			return ErrClashFixingAborted
+		}
+	}
+
+	var composedError error
+
+	for _, r := range renames {
+		message := fmt.Sprintf("Renaming %s %v -> %s\n", r.originalPath, r.change.Src.Id, r.newName)
+		_, err := g.rem.rename(r.change.Src.Id, r.newName)
+		if err == nil {
+			g.log.Log(message)
+			continue
+		}
+
+		composedError = reComposeError(composedError, fmt.Sprintf("%s err: %v", message, err))
+	}
+
+	return composedError
+}

--- a/src/help.go
+++ b/src/help.go
@@ -76,6 +76,7 @@ const (
 	ExcludeOpsKey         = "exclude-ops"
 	IgnoreConflictKey     = "ignore-conflict"
 	IgnoreNameClashesKey  = "ignore-name-clashes"
+	ClashesKey            = "clashes"
 	CommentStr            = "#"
 	DepthKey              = "depth"
 	EmailsKey             = "emails"
@@ -171,11 +172,13 @@ const (
 	DescUrl                = "returns the remote URL of each file"
 	DescVerbose            = "show step by step information verbosely"
 	DescFixClashes         = "fix clashes by renaming files"
+	DescListClashes        = "list clashes"
 	DescDescription        = "set the description"
 	DescQR                 = "open up the QR code for specified files"
 	DescStarred            = "operate only on starred files"
 	DescUnifiedDiff        = "unified diff"
 	DescDiffBaseLocal      = "when set uses local as the base other remote will be used as the base"
+	DescClashesOpById      = "operate on clashes by id instead of by path"
 )
 
 const (
@@ -213,6 +216,8 @@ const (
 	CLIOptionUnified            = "unified"
 	CLIOptionUnifiedShortKey    = "u"
 	CLIOptionDiffBaseLocal      = "base-local"
+	CLIOptionFixClashes         = "fix"
+	CLIOptionListClashes        = "list"
 )
 
 const (

--- a/src/pull.go
+++ b/src/pull.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/odeke-em/drive/config"
@@ -132,74 +131,6 @@ func pull(g *Commands, pt pullType) error {
 	}
 
 	return g.playPullChanges(nonConflicts, g.opts.Exports, opMap)
-}
-
-func autoRenameClashes(g *Commands, clashes []*Change) error {
-
-	clashesMap := map[string][]*Change{}
-
-	for _, clash := range clashes {
-		group := clashesMap[clash.Path]
-		if clash.Src == nil {
-			continue
-		}
-		clashesMap[clash.Path] = append(group, clash)
-	}
-
-	renames := make([]renameOp, 0, len(clashesMap)) // we will have at least len(clashesMap) renames
-
-	for commonPath, group := range clashesMap {
-		ext := filepath.Ext(commonPath)
-		name := strings.TrimSuffix(commonPath, ext)
-		nextIndex := 0
-
-		for i, n := 1, len(group); i < n; i++ { // we can leave first item with original name
-			var newName string
-			for {
-				newName = fmt.Sprintf("%v_%d%v", name, nextIndex, ext)
-				nextIndex++
-
-				dupCheck, err := g.rem.FindByPath(newName)
-				if err != nil && err != ErrPathNotExists {
-					return err
-				}
-
-				if dupCheck == nil {
-					newName = filepath.Base(newName)
-					break
-				}
-			}
-
-			r := renameOp{newName: newName, change: group[i], originalPath: commonPath}
-			renames = append(renames, r)
-		}
-	}
-
-	if g.opts.canPrompt() {
-		g.log.Logln("Some clashes found, we can fix them by following renames:")
-		for _, r := range renames {
-			g.log.Logf("%v %v -> %v\n", r.originalPath, r.change.Src.Id, r.newName)
-		}
-		status := promptForChanges("Proceed with the changes [Y/N] ? ")
-		if !accepted(status) {
-			return ErrClashesDetected
-		}
-	}
-
-	var composedError error
-
-	for _, r := range renames {
-		message := fmt.Sprintf("Renaming %s %v -> %s\n", r.originalPath, r.change.Src.Id, r.newName)
-		_, err := g.rem.rename(r.change.Src.Id, r.newName)
-		if err == nil {
-			g.log.Log(message)
-			continue
-		}
-
-		composedError = reComposeError(composedError, fmt.Sprintf("%s err: %v", message, err))
-	}
-
-	return composedError
 }
 
 func typeById(pt pullType) bool {
@@ -403,6 +334,7 @@ func (g *Commands) pullById() (cl, clashes []*Change, err error) {
 }
 
 func (g *Commands) pullByPath() (cl, clashes []*Change, err error) {
+	fmt.Println("pullByPath")
 	for _, relToRootPath := range g.opts.Sources {
 		fsPath := g.context.AbsPathOf(relToRootPath)
 		ccl, cclashes, cErr := g.changeListResolve(relToRootPath, fsPath, false)

--- a/src/remote.go
+++ b/src/remote.go
@@ -70,6 +70,7 @@ var (
 	ErrNetLookup       = errors.New("net lookup failed")
 	ErrClashesDetected = fmt.Errorf("clashes detected. Use `%s` to override this behavior or `%s` to try fixing this",
 		CLIOptionIgnoreNameClashes, CLIOptionFixClashesKey)
+	ErrClashFixingAborted             = fmt.Errorf("clash fixing aborted")
 	ErrGoogleApiInvalidQueryHardCoded = errors.New("googleapi: Error 400: Invalid query, invalid")
 )
 


### PR DESCRIPTION
Added ability to:
* List clashes.
* Fix clashes.

## Listing clashes
```shell
$ drive clashes dup-tests/a/b/c/d/e
These paths clash
X /dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2Wk9FaEN4ZzNock0
X /dup-tests/a/b/c/d/e/f/g 0By5qQkvRAeV2amN5aFgzc1htVXM
X /dup-tests/a/b/c/d/e/f/g 0By5qQkvRAeV2N21ETkVCTHpkcEE
X /dup-tests/a/b/c/d/e/f/g/h/i 0By5qQkvRAeV2TWdVb29DRlVXR1k
X /dup-tests/a/b/c/d/e/f/g/h/i 0By5qQkvRAeV2Vk9lY3Y2SjFDYlE
X /dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2TzE3LXNWVFNoaHM
X /dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2NmEwUmFQOEZ0dE0
X /dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2bm5ZRVpELXRHTWM
```

## Fixing clashes
```shell
$ drive clashes --fix [paths...]
$ drive clashes  --fix dup-tests/a/b/c/d/e
Some clashes found, we can fix them by following renames:
/dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2TzE3LXNWVFNoaHM -> f_0
/dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2NmEwUmFQOEZ0dE0 -> f_1
/dup-tests/a/b/c/d/e/f 0By5qQkvRAeV2bm5ZRVpELXRHTWM -> f_2
/dup-tests/a/b/c/d/e/f/g 0By5qQkvRAeV2N21ETkVCTHpkcEE -> g_0
/dup-tests/a/b/c/d/e/f/g/h/i 0By5qQkvRAeV2Vk9lY3Y2SjFDYlE -> i_0
Proceed with the changes [Y/N] ? 
```