### PR TITLE
propate no-match found `nil` file after find* channel based queries

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -146,17 +146,18 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, push bool) (cl, c
 	noClashThreshold := uint64(1)
 
 	for rem := range remotesChan {
-		if rem != nil && anyMatch(g.opts.IgnoreRegexp, rem.Name) {
-			return
+		if rem != nil {
+			if anyMatch(g.opts.IgnoreRegexp, rem.Name) {
+				return
+			}
+			iterCount++
 		}
-
-		iterCount++
 
 		ccl, cclashes, cErr := g.byRemoteResolve(relToRoot, fsPath, rem, push)
 
 		cl = append(cl, ccl...)
 		clashes = append(clashes, cclashes...)
-		if false && cErr != nil {
+		if cErr != nil {
 			err = reComposeError(err, cErr.Error())
 		}
 	}

--- a/src/id.go
+++ b/src/id.go
@@ -66,6 +66,7 @@ func (g *Commands) Id() (err error) {
 		iterCount := uint64(0)
 		for rem := range remotes {
 			if rem == nil {
+				err = reComposeError(err, fmt.Sprintf("%s does not exist remotely", customQuote(relToRootPath)))
 				continue
 			}
 

--- a/src/pull.go
+++ b/src/pull.go
@@ -284,6 +284,7 @@ func (g *Commands) PullPiped(byId bool) (err error) {
 		matches := resolver(relToRootPath)
 		for rem := range matches {
 			if rem == nil {
+				err = reComposeError(err, fmt.Sprintf("%s doesnot exist", customQuote(relToRootPath)))
 				continue
 			}
 
@@ -334,16 +335,17 @@ func (g *Commands) pullById() (cl, clashes []*Change, err error) {
 }
 
 func (g *Commands) pullByPath() (cl, clashes []*Change, err error) {
-	fmt.Println("pullByPath")
 	for _, relToRootPath := range g.opts.Sources {
 		fsPath := g.context.AbsPathOf(relToRootPath)
 		ccl, cclashes, cErr := g.changeListResolve(relToRootPath, fsPath, false)
-		clashes = append(clashes, cclashes...)
-		if cErr != nil && cErr != ErrClashesDetected {
-			return cl, clashes, cErr
+		if len(cclashes) > 0 {
+			clashes = append(clashes, cclashes...)
 		}
 		if len(ccl) > 0 {
 			cl = append(cl, ccl...)
+		}
+		if cErr != nil && cErr != ErrClashesDetected {
+			err = reComposeError(err, cErr.Error())
 		}
 	}
 

--- a/src/push.go
+++ b/src/push.go
@@ -328,20 +328,19 @@ func (g *Commands) playPushChanges(cl []*Change, opMap *map[Operation]sizeCounte
 func lonePush(g *Commands, parent, absPath, path string) (cl, clashes []*Change, err error) {
 	remotesChan := g.rem.FindByPathM(absPath)
 
-	iterCount := uint64(0)
-	noClashThreshold := uint64(1)
 	var l *File
 	localinfo, _ := os.Stat(path)
 	if localinfo != nil {
 		l = NewLocalFile(path, localinfo)
 	}
 
-	for r := range remotesChan {
-		if r == nil {
-			continue
-		}
+	iterCount := uint64(0)
+	noClashThreshold := uint64(1)
 
-		iterCount++
+	for r := range remotesChan {
+		if r != nil {
+			iterCount++
+		}
 
 		clr := &changeListResolve{
 			push:   true,

--- a/src/remote.go
+++ b/src/remote.go
@@ -299,7 +299,7 @@ func reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination bool) c
 		defer close(fileChan)
 
 		pageToken := ""
-		for {
+		for pageIterCount := uint64(0); ; pageIterCount++ {
 			if pageToken != "" {
 				req = req.PageToken(pageToken)
 			}
@@ -319,6 +319,10 @@ func reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination bool) c
 			}
 			pageToken = results.NextPageToken
 			if pageToken == "" {
+				if len(results.Items) < 1 && pageIterCount < 1 {
+					// Item absolutely doesn't exist
+					fileChan <- nil
+				}
 				break
 			}
 


### PR DESCRIPTION
Fixes #536.
Updates #528.

It is an offset of PR #528, caused by the new pattern remote.FindByPathM -- multiple which returns a channel. Originally a call
```go
         files, err := req.Do()

        if err != nil {
                if err.Error() == ErrGoogleApiInvalidQueryHardCoded.Error() { // Send the user back the query information
                        err = fmt.Errorf("err: %v query: `%s`", err, expr)
                }
                return nil, err
        }

        if files == nil || len(files.Items) < 1 {
                return nil, ErrPathNotExists
        }

        first := files.Items[0]
        if len(p) == 1 {
                return NewRemoteFile(first), nil
        }
        return r.findByPathRecvRaw(first.Id, p[1:], trashed)
```
The original pattern guaranteed the reporting of unmatched files

and yet now

```go
for rem := range remotesChan {
   ....
}
```
// Will never be run if the file didn't exist upstream.
yet at no point was a lack of the first match ever propagated back with the empty file