### PR TITLE
ignorer: added include + exclude handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,8 +921,24 @@ $ cat << $ >> .driveignore
 ```
 
 
-Note: Pattern matching and suffixes are done by regular expression matching so make sure to use a valid regular expression suffix.
+Note:
+  * Pattern matching and suffixes are done by regular expression matching so make sure to use a valid regular expression suffix.
 
+  * Go doesn't have a negative lookahead mechanism ie `exclude all but` which would
+    normally be achieved in other languages or regex engines by "?!". See https://groups.google.com/forum/#!topic/golang-nuts/7qgSDWPIh_E.
+    This was reported and requested in [issue #535](https://github.com/odeke-em/drive/issues/535).
+    A use case might be ignoring all but say .bashrc files or .dotfiles.
+    To enable this, prefix "!" at the beginning of the path to achieve this behavior.
+
+
+###### Sample .driveignore with the include and exclude clauses combined.
+```shell
+$ cat << $ >> .driveignore
+> ^\.
+> !^\.bashrc # .bashrc files won't be ignored
+> _export$ # _export files are to be ignored
+> !must_export$ # the exception to the clause anything with "must_export"$ won't be ignored
+```
 
 ### DriveRC
 

--- a/src/changes.go
+++ b/src/changes.go
@@ -104,7 +104,7 @@ func (g *Commands) pathResolve() (relPath, absPath string, err error) {
 func (g *Commands) resolveToLocalFile(relToRoot string, fsPaths ...string) (local *File, err error) {
 	checks := append([]string{relToRoot}, fsPaths...)
 
-	if anyMatch(g.opts.IgnoreRegexp, checks...) {
+	if anyMatch(g.opts.Ignorer, checks...) {
 		err = fmt.Errorf("\n'%s' is set to be ignored yet is being processed. Use `%s` to override this\n", relToRoot, ForceKey)
 		return
 	}
@@ -147,7 +147,7 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, push bool) (cl, c
 
 	for rem := range remotesChan {
 		if rem != nil {
-			if anyMatch(g.opts.IgnoreRegexp, rem.Name) {
+			if anyMatch(g.opts.Ignorer, rem.Name) {
 				return
 			}
 			iterCount++
@@ -275,7 +275,7 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 		matchChecks = append(matchChecks, r.Name)
 	}
 
-	if anyMatch(g.opts.IgnoreRegexp, matchChecks...) {
+	if anyMatch(g.opts.Ignorer, matchChecks...) {
 		return
 	}
 
@@ -349,7 +349,7 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 			context: g.context,
 			hidden:  g.opts.Hidden,
 			depth:   originalDepth, // local listing needs to start from original depth
-			ignore:  g.opts.IgnoreRegexp,
+			ignore:  g.opts.Ignorer,
 		}
 
 		localChildren, err = list(&fslArg)

--- a/src/misc_test.go
+++ b/src/misc_test.go
@@ -151,7 +151,7 @@ func TestRetryableErrorCheck(t *testing.T) {
 			value: &tuple{
 				first: "",
 				last: &googleapi.Error{
-					Code: 500,
+					Code:    500,
 					Message: "This is an error",
 				},
 			},
@@ -160,9 +160,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 401,
+					Code:    401,
 					Message: "401 right here",
 				},
 			},
@@ -171,9 +171,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 409,
+					Code:    409,
 					Message: "409 right here",
 				},
 			},
@@ -182,9 +182,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 403,
+					Code:    403,
 					Message: "403 right here",
 				},
 			},
@@ -193,9 +193,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 500,
+					Code:    500,
 					Message: MsgErrFileNotMutable,
 				},
 			},
@@ -204,9 +204,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 500,
+					Code:    500,
 					Message: strings.ToLower(MsgErrFileNotMutable),
 				},
 			},
@@ -215,9 +215,9 @@ func TestRetryableErrorCheck(t *testing.T) {
 		},
 		{
 			value: &tuple{
-				first: nil, 
+				first: nil,
 				last: &googleapi.Error{
-					Code: 501,
+					Code:    501,
 					Message: strings.ToUpper(MsgErrFileNotMutable),
 				},
 			},


### PR DESCRIPTION
Fixes #535.

As of time:"1451307614.785091", Go apparently doesn't have a
"negative lookahead" mechanism ie `ignore all but`. This commit
adds an `exclude but for` clause that mitigates this shortcoming.