### PR TITLE
issue-filing can now be started from the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
   - [Drive Server](#drive-server)
   - [QR Code Share](#qr-code-share)
   - [Star Or Unstar](#star-or-unstar)
+  - [Filing Issues](#filing-issues)
 - [Revoking Account Access](#revoking-account-access)
 - [Uninstalling](#uninstalling)
 - [Applying patches](#applying-patches)
@@ -1100,6 +1101,21 @@ $ drive star --id 0fM9rt0Yc9RTPaDdsNzg1dXVjM0E 0fM9rt0Yc9RTPaTVGc1pzODN1NjQ 0fM9
 ```shell
 $ drive unstar information quest/A/B/C
 $ drive unstar --id 0fM9rt0Yc9RTPaDdsNzg1dXVjM0E 0fM9rt0Yc9RTPaTVGc1pzODN1NjQ 0fM9rt0Yc9RTPV1NaNFp5WlV3dlU
+```
+
+## Filing Issues
+
+In case of any issue, you can file one by using command `issue` aka `report-issue` aka `report`.
+It takes flags `--title` `--body` `--piped`.
+
+* If `--piped` is set, it expects to read the body from standard input).
+
+A successful issue-filing request will open up the project's issue tracker in your web browser.
+
+```
+$ drive issue --title "Can't open my file" --body "Drive trips out everytime"
+$ drive report-issue --title "Can't open my file" --body "Drive trips out everytime"
+$ cat bugReport.txt | drive issue --piped --title "push: dump on pushing from this directory"
 ```
 
 ### Revoking Account Access

--- a/src/help.go
+++ b/src/help.go
@@ -113,6 +113,9 @@ const (
 	PageSizeKey           = "pagesize"
 	DriveRepoRelPath      = "github.com/odeke-em/drive"
 	UrlKey                = "url"
+	ReportIssueKey        = "report-issue"
+	IssueTitleKey         = "title"
+	IssueBodyKey          = "body"
 )
 
 const (
@@ -180,6 +183,9 @@ const (
 	DescUnifiedDiff        = "unified diff"
 	DescDiffBaseLocal      = "when set uses local as the base other remote will be used as the base"
 	DescClashesOpById      = "operate on clashes by id instead of by path"
+	DescIssueBody          = "the detailed description of the issue being filed"
+	DescIssueTitle         = "the title of the issue being filed"
+	DescReportIssue        = "report an issue to the project's issue tracker"
 	DescId                 = "retrieve the fileId for the specified paths"
 )
 
@@ -353,6 +359,7 @@ func createAndRegisterAliases() map[string][]string {
 		DeleteKey:          []string{"del"},
 		EditDescriptionKey: []string{EditDescriptionShortKey},
 		IdKey:              []string{"file-id"},
+		ReportIssueKey:     []string{"issue", "report"},
 	}
 
 	for originalKey, aliasList := range aliases {

--- a/src/issue.go
+++ b/src/issue.go
@@ -1,0 +1,73 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/skratchdot/open-golang/open"
+)
+
+const (
+	ProjectNewIssueUrl = "https://github.com/odeke-em/drive/issues/new"
+)
+
+func (g *Commands) FileIssue() error {
+	title := ""
+	body := ""
+	newIssueRequestUrl := ProjectNewIssueUrl
+
+	piped := false
+
+	meta := g.opts.Meta
+	if meta != nil {
+		metaDeref := *meta
+		titlePieces, _ := metaDeref[IssueTitleKey]
+		title = sepJoin("\n", titlePieces...)
+
+		bodyPieces, _ := metaDeref[IssueBodyKey]
+		body = sepJoin("\n", bodyPieces...)
+
+		if _, pipedSet := metaDeref[PipedKey]; pipedSet { // Intentionally verbose
+			piped = true
+		}
+	}
+
+	if piped {
+		clauses, err := readFileFromStdin(noopOnIgnorer)
+		if err != nil {
+			return err
+		}
+
+		body = sepJoin("\n", clauses...)
+	}
+
+	suffixed := []string{}
+	if trimmedTitle := strings.Trim(title, " "); trimmedTitle != "" {
+		suffixed = append(suffixed, fmt.Sprintf("title=%s", url.QueryEscape(trimmedTitle)))
+	}
+
+	if trimmedBody := strings.Trim(body, " "); trimmedBody != "" {
+		suffixed = append(suffixed, fmt.Sprintf("body=%s", url.QueryEscape(trimmedBody)))
+	}
+
+	if len(suffixed) >= 1 {
+		newIssueRequestUrl += fmt.Sprintf("?%s", sepJoin("&", suffixed...))
+	}
+
+	return open.Run(newIssueRequestUrl)
+}


### PR DESCRIPTION
This requires a web browser for the issues tracker to be opened.
For example:
```shell
$ cat bugReport | drive report-issue --title "Crash on pushing"
$ drive report-issue --title "Crash on pushing" --body "Similar to #5 but here always crashes only after a timeout"
```