### PR TITLE
pptx mimeType corrected

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -546,7 +546,8 @@ var regExtStrMap = map[string]string{
 
 	// docs and docx should not collide if "docx?" is used so terminate with "$"
 	"docx?$": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"pptx?":  "application/vnd.ms-powerpoint",
+	"ppt":    "application/vnd.ms-powerpoint",
+	"pptx":   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 	"tsv":    "text/tab-separated-values",
 	"xlsx?":  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }


### PR DESCRIPTION
Fixes #551.

Ensures that the proper mimeType is used for pptx files
since before the format was that of `open ms-powerpoint`
yet it is `openxmlformats-officedocument.presentationml.presentation`.