### PR TITLE
diff: add skip-content-check flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,11 @@ $ drive diff --base-local=true assignments photos # To use local as the base
 $ drive diff --base-local=false infocom photos # To use remote as the base
 ```
 
+You can only diff for short changes that is only name differences, file modTimes and types, you can use flag `--skip-content-check`.
+
+```shell
+$ drive diff --skip-content-check
+```
 
 ### Touching
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1040,6 +1040,7 @@ type diffCmd struct {
 	Recursive         *bool `json:"recursive"`
 	Unified           *bool `json:"unified"`
 	BaseLocal         *bool `json:"base-local"`
+	SkipContentCheck  *bool `json:"skip-content-check"`
 }
 
 func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1052,6 +1053,7 @@ func (cmd *diffCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Recursive = fs.Bool(drive.RecursiveKey, true, "recursively diff")
 	cmd.Unified = fs.Bool(drive.CLIOptionUnifiedShortKey, true, drive.DescUnifiedDiff)
 	cmd.BaseLocal = fs.Bool(drive.CLIOptionDiffBaseLocal, true, drive.DescDiffBaseLocal)
+	cmd.SkipContentCheck = fs.Bool(drive.SkipContentCheckKey, false, drive.DescSkipContentCheck)
 
 	return fs
 }
@@ -1062,6 +1064,14 @@ func (cmd *diffCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	mask := drive.DiffNone
 	if *cmd.Unified {
 		mask |= drive.DiffUnified
+	}
+
+	var metaPtr *map[string][]string
+	if *cmd.SkipContentCheck {
+		meta := map[string][]string{
+		    drive.SkipContentCheckKey: []string{drive.SkipContentCheckKey},
+		}
+		metaPtr = &meta
 	}
 
 	exitWithError(drive.New(context, &drive.Options{
@@ -1075,6 +1085,7 @@ func (cmd *diffCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		Quiet:             *cmd.Quiet,
 		Depth:             *cmd.Depth,
 		BaseLocal:         *cmd.BaseLocal,
+		Meta:              metaPtr,
 		TypeMask:          mask,
 	}).Diff())
 }

--- a/src/help.go
+++ b/src/help.go
@@ -116,6 +116,7 @@ const (
 	ReportIssueKey        = "report-issue"
 	IssueTitleKey         = "title"
 	IssueBodyKey          = "body"
+	SkipContentCheckKey     = "skip-content-check"
 )
 
 const (
@@ -187,6 +188,7 @@ const (
 	DescIssueTitle         = "the title of the issue being filed"
 	DescReportIssue        = "report an issue to the project's issue tracker"
 	DescId                 = "retrieve the fileId for the specified paths"
+	DescSkipContentCheck   = "skip diffing actual body content, show only name, time, type changes"
 )
 
 const (


### PR DESCRIPTION
Fixes #585.

Adds a flag `--skip-content-check` to diff.
This prevents the need for diffing the content
and just shows only until the time changes.

### Before
```shell
$ drive diff
File: /test-585/influx
* local:          2016-02-12T08:12:09.000Z                
* remote:         2016-02-12T08:10:18.000Z                
influx
****

--- /Users/emmanuelodeke/odeke@ualberta.ca/test-585/influx	2016-02-12 00:12:09.000000000 -0800
+++ .xtmp5577006791947779410.tmp522394888	2016-02-12 00:12:54.000000000 -0800
@@ -1,7 +1,2 @@
 admin
 influx
-admin
-influx
-off
-off1
-today

****
/test-585/off1 only on local
/test-585/today only on local
/test-585/off only on local
```

### After, with `--skip-content-check`
```shell
drive diff --skip-content-check
File: /test-585/influx
* local:          2016-02-12T08:12:09.000Z                
* remote:         2016-02-12T08:10:18.000Z                
influx
****

/test-585/off only on local
/test-585/off1 only on local
/test-585/today only on local
```