### PR TITLE
pull/export: fixed ppt vs pptx regex ambiguity

### DIFF
--- a/src/help.go
+++ b/src/help.go
@@ -116,7 +116,7 @@ const (
 	ReportIssueKey        = "report-issue"
 	IssueTitleKey         = "title"
 	IssueBodyKey          = "body"
-	SkipContentCheckKey     = "skip-content-check"
+	SkipContentCheckKey   = "skip-content-check"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -546,8 +546,8 @@ var regExtStrMap = map[string]string{
 
 	// docs and docx should not collide if "docx?" is used so terminate with "$"
 	"docx?$": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-	"ppt":    "application/vnd.ms-powerpoint",
-	"pptx":   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+	"ppt$":   "application/vnd.ms-powerpoint",
+	"pptx$":  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 	"tsv":    "text/tab-separated-values",
 	"xlsx?":  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }


### PR DESCRIPTION
Fixes #583.
Updates #551.

Fixes an ambiguity with the regexes for `ppt` and `pptx`.
The problem was that `ppt` and `pptx` are unterminated regex-wise
so `pptx` would get matched as `ppt` and then undeterministically
also matched as `pptx`.
This mean that `pptx` would give two different mimeTypes ie
```json
	"ppt":    "application/vnd.ms-powerpoint",
	"pptx":   "application/vnd.openxmlformats-officedocument.presentationml.presentation"
```

The fix is to terminate them as `ppt$` and `pptx$` to properly
differentiate between the two.