### PR TITLE
edit-desc: fix error handling to get proper return code

### DIFF
--- a/src/edit.go
+++ b/src/edit.go
@@ -59,7 +59,7 @@ func (g *Commands) EditDescription(byId bool) (composedErr error) {
 	for kv := range kvChan {
 		file, ok := kv.value.(*File)
 		if !ok {
-			g.log.LogErrf("%s: %s\n", kv.key, kv.value)
+			composedErr = reComposeError(composedErr, fmt.Sprintf("%s: %s", kv.key, kv.value))
 			continue
 		}
 
@@ -79,5 +79,5 @@ func (g *Commands) EditDescription(byId bool) (composedErr error) {
 		}
 	}
 
-	return
+	return composedErr
 }


### PR DESCRIPTION
This patch improves error handling in EditDescription.
drive edit-desc returned 0 in some cases, like "remote path doesn't exist".

Fix the following issue where rc=0:

```
$ drive edit-desc gdrive/regal/e6/2d/bb/0x200010896:0x1f237:0x0
Using an empty description will clear out the previous one
Proceed with the changes? [Y/n]:y
/gdrive/regal/e6/2d/bb/0x200010896:0x1f237:0x0: remote path doesn't exist
$ echo $?
0
```

With this patch, rc=1 instead.