### PR TITLE
implemented errors with status/return codes.

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1714,10 +1714,19 @@ func uniqOrderedStr(sources []string) []string {
 }
 
 func exitWithError(err error) {
-	if err != nil {
-		drive.FprintfShadow(os.Stderr, "%v\n", err)
-		os.Exit(1)
+	if err == nil {
+		return
 	}
+
+	msg := err.Error()
+	code := -1
+
+	if codedErr, ok := err.(*drive.Error); ok {
+		code = codedErr.Code()
+	}
+
+	drive.FprintfShadow(os.Stderr, "%s\n", msg)
+	os.Exit(code)
 }
 
 func relativePaths(root string, args ...string) ([]string, error) {

--- a/src/changes.go
+++ b/src/changes.go
@@ -105,7 +105,7 @@ func (g *Commands) resolveToLocalFile(relToRoot string, fsPaths ...string) (loca
 	checks := append([]string{relToRoot}, fsPaths...)
 
 	if anyMatch(g.opts.Ignorer, checks...) {
-		err = fmt.Errorf("\n'%s' is set to be ignored yet is being processed. Use `%s` to override this\n", relToRoot, ForceKey)
+		err = illogicalStateErr(fmt.Errorf("\n'%s' is set to be ignored yet is being processed. Use `%s` to override this\n", relToRoot, ForceKey))
 		return
 	}
 
@@ -117,7 +117,7 @@ func (g *Commands) resolveToLocalFile(relToRoot string, fsPaths ...string) (loca
 			return
 		} else if localInfo != nil {
 			if namedPipe(localInfo.Mode()) {
-				err = fmt.Errorf("%s (%s) is a named pipe, yet not reading from it", relToRoot, fsPath)
+				err = namedPipeReadAttemptErr(fmt.Errorf("%s (%s) is a named pipe, yet not reading from it", relToRoot, fsPath))
 				return
 			}
 
@@ -158,7 +158,7 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, push bool) (cl, c
 		cl = append(cl, ccl...)
 		clashes = append(clashes, cclashes...)
 		if cErr != nil {
-			err = reComposeError(err, cErr.Error())
+			err = combineErrors(err, cErr)
 		}
 	}
 
@@ -172,8 +172,8 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, push bool) (cl, c
 
 func (g *Commands) doChangeListRecv(relToRoot, fsPath string, l, r *File, push bool) (cl, clashes []*Change, err error) {
 	if l == nil && r == nil {
-		err = fmt.Errorf("'%s' aka '%s' doesn't exist locally nor remotely",
-			relToRoot, fsPath)
+		err = illogicalStateErr(fmt.Errorf("'%s' aka '%s' doesn't exist locally nor remotely",
+			relToRoot, fsPath))
 		return
 	}
 

--- a/src/clashes.go
+++ b/src/clashes.go
@@ -108,7 +108,7 @@ func findClashesForChildren(g *Commands, parentId, relToRootPath string, depth i
 			ccl, cErr := findClashesForChildren(g, rem.Id, fullRelToRootPath, decrementedDepth)
 			clashes = append(clashes, ccl...)
 			if cErr != nil {
-				err = reComposeError(err, cErr.Error())
+				err = combineErrors(err, cErr)
 			}
 		}
 	}
@@ -156,7 +156,7 @@ func findClashesByPath(g *Commands, relToRootPath string, depth int) (clashes []
 	for _, change := range cl {
 		ccl, cErr := findClashesForChildren(g, change.Src.Id, change.Path, decrementedDepth)
 		if cErr != nil {
-			err = reComposeError(err, cErr.Error())
+			err = combineErrors(err, cErr)
 		}
 
 		clashes = append(clashes, ccl...)
@@ -172,7 +172,7 @@ func listClashes(g *Commands, sources []string, byId bool) (clashes []*Change, e
 		clashes = append(clashes, cclashes...)
 
 		if cErr != nil {
-			err = reComposeError(err, cErr.Error())
+			err = combineErrors(err, cErr)
 		}
 	}
 

--- a/src/copy.go
+++ b/src/copy.go
@@ -30,7 +30,7 @@ type copyArgs struct {
 func (g *Commands) Copy(byId bool) error {
 	argc := len(g.opts.Sources)
 	if argc < 2 {
-		return fmt.Errorf("expecting src [src1....] dest got: %v", g.opts.Sources)
+		return invalidArgumentsErr(fmt.Errorf("expecting src [src1....] dest got: %v", g.opts.Sources))
 	}
 
 	g.log.Logln("Processing...")
@@ -44,13 +44,13 @@ func (g *Commands) Copy(byId bool) error {
 
 	destFile, err := g.rem.FindByPath(dest)
 	if err != nil && err != ErrPathNotExists {
-		return fmt.Errorf("destination: %s err: %v", dest, err)
+		return remoteLookupErr(fmt.Errorf("destination: %s err: %v", dest, err))
 	}
 
 	multiPaths := len(sources) > 1
 	if multiPaths {
 		if destFile != nil && !destFile.IsDir {
-			return fmt.Errorf("%s: %v", dest, ErrPathNotDir)
+			return illogicalStateErr(fmt.Errorf("%s: %v", dest, ErrPathNotDir))
 		}
 		_, err := g.remoteMkdirAll(dest)
 		if err != nil {
@@ -93,12 +93,12 @@ func (g *Commands) Copy(byId bool) error {
 
 func (g *Commands) copy(src *File, destPath string) (*File, error) {
 	if src == nil {
-		return nil, fmt.Errorf("non existent src")
+		return nil, illogicalStateErr(fmt.Errorf("non existent src"))
 	}
 
 	if !src.IsDir {
 		if !src.Copyable {
-			return nil, fmt.Errorf("%s is non-copyable", src.Name)
+			return nil, illogicalStateErr(fmt.Errorf("%s is non-copyable", src.Name))
 		}
 
 		destDir, destBase := g.pathSplitter(destPath)

--- a/src/diff.go
+++ b/src/diff.go
@@ -41,7 +41,11 @@ type diffSt struct {
 	cwd          string
 	mask         int
 	printRuler   bool
-	// baseLocal when set uses local as the base otherwise remote is used as the base
+	// skipContentCheck when set prevents content
+	// diffing, but only time differences.
+	skipContentCheck bool
+	// baseLocal when set uses local as the base
+	// otherwise remote is used as the base.
 	baseLocal bool
 }
 
@@ -67,7 +71,7 @@ func (g *Commands) Diff() (err error) {
 			if cErr != ErrClashesDetected {
 				return cErr
 			} else {
-				err = reComposeError(err, cErr.Error())
+				err = combineErrors(err, cErr)
 			}
 		}
 
@@ -100,6 +104,12 @@ func (g *Commands) Diff() (err error) {
 		baseLocal:    g.opts.BaseLocal,
 	}
 
+	metaPtr := g.opts.Meta
+	if metaPtr != nil {
+		meta := *metaPtr
+		_, dst.skipContentCheck = meta[SkipContentCheckKey]
+	}
+
 	for _, c := range cl {
 		dst.change = c
 		dErr := g.perDiff(dst)
@@ -116,37 +126,27 @@ func (g *Commands) perDiff(dSt diffSt) (err error) {
 
 	l, r := change.Src, change.Dest
 	if l == nil && r == nil {
-		return fmt.Errorf("Neither remote nor local exists")
+		return illogicalStateErr(fmt.Errorf("Neither remote nor local exists"))
 	}
 	if r == nil && l != nil {
-		return fmt.Errorf("%s only on local", change.Path)
+		return illogicalStateErr(fmt.Errorf("%s only on local", change.Path))
 	}
 	if l == nil && r != nil {
-		return fmt.Errorf("%s only on remote", change.Path)
+		return illogicalStateErr(fmt.Errorf("%s only on remote", change.Path))
 	}
+
 	// Pre-screening phase
 	if r.IsDir && l.IsDir {
-		return fmt.Errorf("Both local and remote are directories")
+		// Note that if they are both directories, comparing times is spurious
+		// see issues #304, #471, #477 and PR #478.
+		return illogicalStateErr(fmt.Errorf("Both local and remote are directories"))
 	}
 	if r.IsDir && !l.IsDir {
-		return fmt.Errorf("Remote is a directory while local is an ordinary file")
+		return illogicalStateErr(fmt.Errorf("Remote is a directory while local is an ordinary file"))
 	}
 
 	if l.IsDir && !r.IsDir {
-		return fmt.Errorf("Local is a directory while remote is an ordinary file")
-	}
-
-	if r.BlobAt == "" {
-		return fmt.Errorf("Cannot access download link for '%v'", r.Name)
-	}
-
-	if r.Size > MaxFileSize {
-		return fmt.Errorf("%s Remote too large for display \033[94m[%v bytes]\033[00m",
-			change.Path, r.Size)
-	}
-	if l.Size > MaxFileSize {
-		return fmt.Errorf("%s Local too large for display \033[92m[%v bytes]\033[00m",
-			change.Path, l.Size)
+		return illogicalStateErr(fmt.Errorf("Local is a directory while remote is an ordinary file"))
 	}
 
 	mask := fileDifferences(r, l, g.opts.IgnoreChecksum)
@@ -170,11 +170,34 @@ func (g *Commands) perDiff(dSt diffSt) (err error) {
 		}
 	}
 
+	if l.Name != r.Name {
+		g.log.Logf("%s %s\n%s\n\n", l.Name, r.Name, Ruler)
+	} else {
+		g.log.Logf("%s\n%s\n\n", l.Name, Ruler)
+	}
+
+	if dSt.skipContentCheck {
+		return
+	}
+
 	defer func() {
 		if dSt.printRuler {
 			g.log.Logf("\n%s\n", Ruler)
 		}
 	}()
+
+	if r.BlobAt == "" {
+		return illogicalStateErr(fmt.Errorf("Cannot access download link for '%v'", r.Name))
+	}
+
+	if r.Size > MaxFileSize {
+		return contentTooLargeErr(fmt.Errorf("%s Remote too large for display \033[94m[%v bytes]\033[00m",
+			change.Path, r.Size))
+	}
+	if l.Size > MaxFileSize {
+		return contentTooLargeErr(fmt.Errorf("%s Local too large for display \033[92m[%v bytes]\033[00m",
+			change.Path, l.Size))
+	}
 
 	var frTmp, fl *os.File
 	var blob io.ReadCloser
@@ -210,12 +233,6 @@ func (g *Commands) perDiff(dSt diffSt) (err error) {
 	_, err = io.Copy(frTmp, blob)
 	if err != nil {
 		return
-	}
-
-	if l.Name != r.Name {
-		g.log.Logf("%s %s\n%s\n\n", l.Name, r.Name, Ruler)
-	} else {
-		g.log.Logf("%s\n%s\n\n", l.Name, Ruler)
 	}
 
 	diffArgs := []string{diffProgPath}

--- a/src/errors.go
+++ b/src/errors.go
@@ -1,0 +1,153 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+type ErrorStatus int
+
+const (
+	StatusGeneric                     ErrorStatus = 1
+	StatusAuthenticationFailed        ErrorStatus = 2
+	StatusRetriesExhausted            ErrorStatus = 3
+	StatusDownloadFailed              ErrorStatus = 4
+	StatusPullFailed                  ErrorStatus = 5
+	StatusGoogleDocNonExportAttempted ErrorStatus = 6
+	StatusInvalidGoogleAPIQuery       ErrorStatus = 7
+	StatusIllogicalState              ErrorStatus = 8
+	StatusNonExistantRemote           ErrorStatus = 9
+	StatusRemoteLookupFailed          ErrorStatus = 10
+	StatusLocalLookupFailed           ErrorStatus = 11
+	StatusNetLookupFailed             ErrorStatus = 12
+	StatusClashesDetected             ErrorStatus = 13
+	StatusClashFixingAborted          ErrorStatus = 14
+	StatusMkdirFailed                 ErrorStatus = 15
+	StatusNoMatchesFound              ErrorStatus = 16
+	StatusUnresolvedConflicts         ErrorStatus = 17
+	StatusCannotPrompt                ErrorStatus = 18
+	StatusOverwriteAttempted          ErrorStatus = 19
+	StatusImmutableOperationAttempted ErrorStatus = 20
+	StatusInvalidArguments            ErrorStatus = 21
+	StatusNamedPipeReadAttempt        ErrorStatus = 22
+	StatusContentTooLarge             ErrorStatus = 23
+)
+
+type Error struct {
+	code   ErrorStatus
+	status string
+	err    error
+}
+
+func (e Error) Error() string {
+	joins := []string{}
+	if e.status != "" {
+		joins = append(joins, e.status)
+	}
+	if e.err != nil {
+		joins = append(joins, e.err.Error())
+	}
+	return sepJoin(" ", joins...)
+}
+
+func (e Error) Code() int {
+	return int(e.code)
+}
+
+func makeError(err error, code ErrorStatus) *Error {
+	return &Error{
+		code: code,
+		err:  err,
+	}
+}
+
+func makeErrorWithStatus(status string, err error, code ErrorStatus) *Error {
+	e := makeError(err, code)
+	e.status = status
+	return e
+}
+
+func googleDocNonExportErr(err error) *Error {
+	return makeError(err, StatusGoogleDocNonExportAttempted)
+}
+
+func downloadFailedErr(err error) *Error {
+	return makeError(err, StatusDownloadFailed)
+}
+
+func illogicalStateErr(err error) *Error {
+	return makeError(err, StatusIllogicalState)
+}
+
+func invalidGoogleAPIQueryErr(err error) *Error {
+	return makeError(err, StatusInvalidGoogleAPIQuery)
+}
+
+func nonExistantRemoteErr(err error) *Error {
+	return makeError(err, StatusNonExistantRemote)
+}
+
+func netLookupFailedErr(err error) *Error {
+	return makeError(err, StatusNetLookupFailed)
+}
+
+func clashesDetectedErr(err error) *Error {
+	return makeError(err, StatusClashesDetected)
+}
+
+func clashFixingAbortedErr(err error) *Error {
+	return makeError(err, StatusClashFixingAborted)
+}
+
+func mkdirFailedErr(err error) *Error {
+	return makeError(err, StatusMkdirFailed)
+}
+
+func noMatchesFoundErr(err error) *Error {
+	return makeError(err, StatusNoMatchesFound)
+}
+
+func unresolvedConflictsErr(err error) *Error {
+	return makeError(err, StatusUnresolvedConflicts)
+}
+
+func pullFailedErr(err error) *Error {
+	return makeError(err, StatusPullFailed)
+}
+
+func cannotPromptErr(err error) *Error {
+	return makeError(err, StatusCannotPrompt)
+}
+
+func overwriteAttemptedErr(err error) *Error {
+	return makeError(err, StatusOverwriteAttempted)
+}
+
+func immutableAttemptErr(err error) *Error {
+	return makeError(err, StatusImmutableOperationAttempted)
+}
+
+func remoteLookupErr(err error) *Error {
+	return makeError(err, StatusRemoteLookupFailed)
+}
+
+func invalidArgumentsErr(err error) *Error {
+	return makeError(err, StatusInvalidArguments)
+}
+
+func namedPipeReadAttemptErr(err error) *Error {
+	return makeError(err, StatusNamedPipeReadAttempt)
+}
+
+func contentTooLargeErr(err error) *Error {
+	return makeError(err, StatusContentTooLarge)
+}

--- a/src/errors_test.go
+++ b/src/errors_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drive
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestErrors(t *testing.T) {
+	testCases := [...]struct {
+		e             *Error
+		wantErrString string
+		wantCode      int
+	}{
+		0: {
+			e: &Error{
+				status: "foo",
+				code:   StatusIllogicalState,
+			},
+			wantErrString: "foo",
+			wantCode:      int(StatusIllogicalState),
+		},
+		1: {
+			e: &Error{
+				err:    fmt.Errorf("bar"),
+				status: "first",
+			},
+			wantErrString: "first bar",
+			wantCode:      0,
+		},
+		2: {
+			e: &Error{
+				err:    fmt.Errorf("bar"),
+				status: "first",
+				code:   StatusInvalidGoogleAPIQuery,
+			},
+			wantErrString: "first bar",
+			wantCode:      int(StatusInvalidGoogleAPIQuery),
+		},
+		3: {
+			e:             makeError(fmt.Errorf("golang"), StatusNonExistantRemote),
+			wantErrString: "golang",
+			wantCode:      int(StatusNonExistantRemote),
+		},
+		4: {
+			e:             makeErrorWithStatus("drive over errthang", fmt.Errorf("truu"), StatusUnresolvedConflicts),
+			wantErrString: "drive over errthang truu",
+			wantCode:      int(StatusUnresolvedConflicts),
+		},
+	}
+
+	for i, tc := range testCases {
+		gotString, wantString := tc.e.Error(), tc.wantErrString
+		if !strings.EqualFold(gotString, wantString) {
+			t.Errorf("#%d got=%q want=%q", i, gotString, wantString)
+		}
+
+		gotCode, wantCode := tc.e.Code(), tc.wantCode
+		if gotCode != wantCode {
+			t.Errorf("#%d code: got=%v want=%v", i, gotCode, wantCode)
+		}
+	}
+}

--- a/src/id.go
+++ b/src/id.go
@@ -50,7 +50,7 @@ func idPrintAndRecurse(g *Commands, parentId, relToRootPath string, depth int) (
 		childRelToRootPath := sepJoin(RemoteSeparator, separatorPrefix, child.Name)
 		cErr := idPrintAndRecurse(g, child.Id, childRelToRootPath, decrementedDepth)
 		if cErr != nil {
-			err = reComposeError(err, cErr.Error())
+			err = combineErrors(err, cErr)
 		}
 	}
 
@@ -78,7 +78,7 @@ func (g *Commands) Id() (err error) {
 			iterCount++
 			cErr := idPrintAndRecurse(g, rem.Id, relToRootPath, g.opts.Depth)
 			if cErr != nil {
-				err = reComposeError(err, cErr.Error())
+				err = combineErrors(err, cErr)
 			}
 		}
 

--- a/src/list.go
+++ b/src/list.go
@@ -191,7 +191,7 @@ func (g *Commands) List(byId bool) error {
 	for _, relPath := range g.opts.Sources {
 		r, rErr := resolver(relPath)
 		if rErr != nil && rErr != ErrPathNotExists {
-			return fmt.Errorf("%v: '%s'", rErr, relPath)
+			return illogicalStateErr(fmt.Errorf("%v: '%s'", rErr, relPath))
 		}
 
 		if r == nil {

--- a/src/share.go
+++ b/src/share.go
@@ -302,7 +302,7 @@ func (c *Commands) playShareChanges(change *shareChange) (err error) {
 	}
 
 	if successes < 1 {
-		return fmt.Errorf("no matches found!")
+		return noMatchesFoundErr(fmt.Errorf("no matches found!"))
 	}
 
 	return err

--- a/src/trash.go
+++ b/src/trash.go
@@ -94,7 +94,7 @@ func (g *Commands) EmptyTrash() error {
 func (g *Commands) trasher(relToRoot string, opt *trashOpt) (*Change, error) {
 	var file *File
 	if relToRoot == "/" && opt.toTrash {
-		return nil, fmt.Errorf("Will not try to trash root.")
+		return nil, immutableAttemptErr(fmt.Errorf("Will not try to trash root."))
 	}
 	resolver := g.rem.FindByPathTrashed
 	if opt.byId {
@@ -111,7 +111,7 @@ func (g *Commands) trasher(relToRoot string, opt *trashOpt) (*Change, error) {
 	if opt.byId {
 		if file.Labels != nil {
 			if file.Labels.Trashed == opt.toTrash {
-				return nil, fmt.Errorf("toTrash=%v set yet already file.Trash=%v", opt.toTrash, file.Labels.Trashed)
+				return nil, illogicalStateErr(fmt.Errorf("toTrash=%v set yet already file.Trash=%v", opt.toTrash, file.Labels.Trashed))
 			}
 		}
 		relToRoot = fmt.Sprintf("%s (%s)", relToRoot, file.Name)
@@ -158,7 +158,7 @@ func (g *Commands) trashByMatch(inTrash, permanent bool) error {
 	}
 
 	if len(cl) < 1 {
-		return fmt.Errorf("no matches found!")
+		return noMatchesFoundErr(fmt.Errorf("no matches found!"))
 	}
 
 	clArg := changeListArg{


### PR DESCRIPTION
Fixes #479.

Now most errors returned from drive have a status/return
code that will be passed to the external environment on failure.

- Before
```shell
$ drive pull nonExistant
Resolving...
 –
'/ysms' aka '/Users/emmanuelodeke/emm.odeke/nonExistant' doesn't
exist locally nor remotely
$ echo $?
1
$ mkfifo pxm
$ drive push pxm
Resolving...
 –
/pxm (/Users/emmanuelodeke/emm.odeke/pxm) is a named pipe, yet
not reading from it
$ echo $?
1
```

- After
```shell
$ drive pull nonExistant
$ echo $?
8
$ mkfifo pxm
$ drive push pxm
Resolving...
 –
/pxm (/Users/emmanuelodeke/emm.odeke/pxm) is a named pipe, yet
not reading from it
$ echo $?
22
```