### PR TITLE
push: added --destination arbitrary within root pushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,17 @@ Like `pull`, you can run it without any arguments to push all of the files from 
 $ drive push --depth 1 head-folders
 ```
 
+You can also push multiple paths that are children of the root of the mounted drive to a destination,
+
+in relation to issue #612, using key `--destination`:
+
+For example to push the content of `music/Travi$+Future`, `integrals/complex/compilations` directly to `a1/b2/c3`:
+
+```shell
+$ drive push --destination a1/b2/c3 music/Travi$+Future integrals/complex/compilations
+```
+
+
 Note: To ignore checksum verification during a push:
 
 ```shell

--- a/src/changes.go
+++ b/src/changes.go
@@ -178,10 +178,14 @@ func (g *Commands) doChangeListRecv(relToRoot, fsPath string, l, r *File, push b
 	}
 
 	dirname := path.Dir(relToRoot)
+	base := relToRoot
+	if relBase, err := filepath.Rel(g.context.AbsPathOf(""), fsPath); err == nil {
+		base = relBase
+	}
 
 	clr := &changeListResolve{
 		dir:    dirname,
-		base:   relToRoot,
+		base:   base,
 		local:  l,
 		push:   push,
 		remote: r,
@@ -352,8 +356,10 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 			ignore:  g.opts.Ignorer,
 		}
 
-		localChildren, err = list(&fslArg)
-		if err != nil {
+		var lErr error
+		localChildren, lErr = list(&fslArg)
+		if lErr != nil && !os.IsNotExist(lErr) {
+			err = lErr
 			return
 		}
 	}

--- a/src/commands.go
+++ b/src/commands.go
@@ -86,6 +86,10 @@ type Options struct {
 	// BaseLocal when set, during a diff uses the local file
 	// as the base otherwise remote is used as the base
 	BaseLocal bool
+	// Destination when set is the final logical location of the
+	// constituents of an operation for example a push or pull.
+	// See issue #612.
+	Destination string
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -189,6 +189,7 @@ const (
 	DescReportIssue        = "report an issue to the project's issue tracker"
 	DescId                 = "retrieve the fileId for the specified paths"
 	DescSkipContentCheck   = "skip diffing actual body content, show only name, time, type changes"
+	DescPushDestination    = "specify the final destination of the contents of an operation"
 )
 
 const (
@@ -228,6 +229,7 @@ const (
 	CLIOptionDiffBaseLocal      = "base-local"
 	CLIOptionFixClashes         = "fix"
 	CLIOptionListClashes        = "list"
+	CLIOptionPushDestination    = "destination"
 )
 
 const (

--- a/src/misc.go
+++ b/src/misc.go
@@ -279,6 +279,13 @@ func sepJoinNonEmpty(sep string, args ...string) string {
 	return sepJoin(sep, nonEmpties...)
 }
 
+func remotePathJoin(segments ...string) string {
+	// Always ensure that the first segment is the remoteSeparator
+	segments = append([]string{RemoteSeparator}, segments...)
+	joins := sepJoinNonEmpty(RemoteSeparator, segments...)
+	return path.Clean(joins)
+}
+
 func isHidden(p string, ignore bool) bool {
 	if strings.HasPrefix(p, ".") {
 		return !ignore

--- a/src/remote.go
+++ b/src/remote.go
@@ -794,7 +794,15 @@ func (r *Remote) UpsertByComparison(args *upsertOpt) (f *File, err error) {
 
 	var body io.Reader
 	if !args.src.IsDir {
-		body, err = os.Open(args.fsAbsPath)
+		// In relation to issue #612, since we are not only resolving
+		// relative to the current working directory, we should try reading
+		// first from the source's original local fsAbsPath aka `BlobAt`
+		// because the resolved path might be different from the original path.
+		fsAbsPath := args.src.BlobAt
+		if fsAbsPath == "" {
+			fsAbsPath = args.fsAbsPath
+		}
+		body, err = os.Open(fsAbsPath)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Added the ability to push directly to a final destination
without copying content, remotely/locally nor moving, using
option `--destination`.

- Sample usage:

To push the content of `music/Travi$+Future`, `integrals/complex/compilations` directly to `a1/b2/c3`:

```shell
$ drive push --destination a1/b2/c3 music/Travi$+Future integrals/complex/compilations
```
where the sources exist on disk.

Fixes #612.