### PR TITLE
push/changes: keep track of local vs remote base

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -279,11 +279,19 @@ func sepJoinNonEmpty(sep string, args ...string) string {
 	return sepJoin(sep, nonEmpties...)
 }
 
-func remotePathJoin(segments ...string) string {
-	// Always ensure that the first segment is the remoteSeparator
-	segments = append([]string{RemoteSeparator}, segments...)
-	joins := sepJoinNonEmpty(RemoteSeparator, segments...)
+func _centricPathJoin(sep string, segments ...string) string {
+	// Always ensure that the first segment is the separator
+	segments = append([]string{sep}, segments...)
+	joins := sepJoinNonEmpty(sep, segments...)
 	return path.Clean(joins)
+}
+
+func localPathJoin(segments ...string) string {
+	return _centricPathJoin(UnescapedPathSep, segments...)
+}
+
+func remotePathJoin(segments ...string) string {
+	return _centricPathJoin(RemoteSeparator, segments...)
 }
 
 func isHidden(p string, ignore bool) bool {

--- a/src/push.go
+++ b/src/push.go
@@ -350,12 +350,12 @@ func lonePush(g *Commands, parent, absPath, path string) (cl, clashes []*Change,
 		}
 
 		clr := &changeListResolve{
-			push:   true,
-			dir:    parent,
-			base:   absPath,
-			remote: r,
-			local:  l,
-			depth:  g.opts.Depth,
+			remote:    r,
+			local:     l,
+			push:      true,
+			dir:       parent,
+			localBase: absPath,
+			depth:     g.opts.Depth,
 		}
 
 		ccl, cclashes, cErr := g.resolveChangeListRecv(clr)


### PR DESCRIPTION
Keep track of the local vs remote base since we are no longer
only pushing from a single location on disk/local.
Also ensure that all paths in a push/changelist-resolve are
separator prefixed since searching for remote files always
starts with '/' as was the old style. Passing in say 'lib/f1'
is invalid since the search starts from '/' so must be '/lib/f1'.

Fixes #618
Updates #616
Updates #612