### PR TITLE
push -piped: return error in case of remoteMkdirAll failure

### DIFF
--- a/src/push.go
+++ b/src/push.go
@@ -209,8 +209,8 @@ func (g *Commands) PushPiped() (err error) {
 			parent, pErr = g.remoteMkdirAll(parentPath)
 			spin.stop()
 			if pErr != nil || parent == nil {
-				g.log.LogErrf("%s: %v", relToRootPath, pErr)
-				return
+				g.log.LogErrf("%s: %v\n", relToRootPath, pErr)
+				return pErr
 			}
 		}
 


### PR DESCRIPTION
Hi @odeke-em This is a small change I made after noticing a few rare cases of push -piped failing but return code was 0. I tested this fix during a few hours without seeing the problem anymore.