### PR TITLE
rename: add local + remote modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,10 @@ $ drive copy -r --id 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 0fM9rt0Yc9kJRPSTFNk9kSTVvb0U .
 
 ### Rename
 
-drive allows you to rename a file/folder remotely. To do so:
+drive allows you to rename a file/folder remotely.
+Two arguments are required to rename ie `<relativePath/To/source or Id>` `<newName>`.
+
+To perform a rename:
 
 ```shell
 $ drive rename url_test url_test_results
@@ -891,6 +894,17 @@ $ drive rename openSrc/2015 2015-Contributions
 ```shell
 $ drive rename 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 fluxing
 ```
+
+
+To turn off renaming locally or remotely, use flags
+`--local=false` or `--remote=false`. By default both are turned on.
+
+For example
+
+```shell
+$ drive rename --local=false --remote=true a/b/c/d/e/f flux
+```
+
 
 ### Clashes
 

--- a/src/commands.go
+++ b/src/commands.go
@@ -90,6 +90,7 @@ type Options struct {
 	// constituents of an operation for example a push or pull.
 	// See issue #612.
 	Destination string
+	RenameMode  RenameMode
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -230,6 +230,8 @@ const (
 	CLIOptionFixClashes         = "fix"
 	CLIOptionListClashes        = "list"
 	CLIOptionPushDestination    = "destination"
+	CLIOptionRenameLocal        = "local"
+	CLIOptionRenameRemote       = "remote"
 )
 
 const (


### PR DESCRIPTION
By default, rename will also rename the equivalent local path.
This CL also allows toggling whether to rename local or remote.
However, it resolves the file to change based off the remote path

- To turn off local renaming
```shell
$ drive rename --local=false a/b/c/d pam
```

- To turn off remote renaming
```shell
$ drive rename --remote=false bcd tkf
```

It also warns the user of an error if they turn off all modes.
```shell
$ drive rename --local=false --remote=false 5 6
no rename mode set, set either `local` or `remote` mode
$ echo $?
8
```

Fixes #459.