### PR TITLE
README: min go version bumped to go1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@
 
 ## Requirements
 
-go 1.3.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
+go 1.5.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
 
 * Make sure to set your GOPATH in your env, .bashrc or .bash\_profile file. If you have not yet set it, you can do so like this:
 


### PR DESCRIPTION
Because of dependency requirements calling for at least go1.5, we need to
bump the requirement in the README.

```shell
$ go get -u github.com/odeke-em/drive/cmd/drive
golang.org/x/net/context/ctxhttp
../gopath/src/golang.org/x/net/context/ctxhttp/ctxhttp.go:35: req.Cancel
undefined (type *http.Request has no field or method Cancel)
```

Fixes #630.
Updates #627.