### PR TITLE
E2E: encrypt on upload, decrypt on download

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Usage](#usage)
   - [Initializing](#initializing)
   - [De Initializing](#de-initializing)
+  - [End to End Encryption](#end-to-end-encryption)
   - [Traversal Depth](#traversal-depth)
   - [Pulling](#pulling)
     - [Exporting Docs](#exporting-docs)
@@ -221,6 +222,14 @@ Run it without any arguments to pull all of the files from the current path:
 $ drive pull
 ```
 
+To pull and decrypt your data that is stored encrypted at rest on Google Drive, use flag `--decryption-password`:
+
+See [Issue #543](https://github.com/odeke-em/issues/543)
+
+```shell
+$ drive pull --decryption-password "$JiME5Umf" influx.txt
+```
+
 Pulling by matches is also supported
 
 ```shell
@@ -359,6 +368,13 @@ Note: To ignore checksum verification during a push:
 $ drive push -ignore-checksum
 ```
 
+To keep your data encrypted at rest remotely on Google Drive:
+
+```shell
+$ drive push --encryption-password "$JiME5Umf" influx.txt
+```
+For E2E discussions, see [issue #543](https://github.com/odeke-em/issues/543):
+
 drive also supports pushing content piped from stdin which can be accomplished by:
 
 ```shell
@@ -469,6 +485,39 @@ default count of 20:
 ```shell
 $ drive push --retry-count 4 a/bc/def terms
 ```
+
+### End to End Encryption
+
+See [Issue #543](https://github.com/odeke-em/issues/543)
+
+This can be toggled when you supply a non-empty password ie
+
+- `--encryption-password` for a push.
+- `--decryption-password` for a pull.
+
+When you supply argument `--encryption-password` during a push, drive will encrypt your data
+and store it remotely encrypted(stored encrypted at rest), it can only be decrypted by you when you
+perform a pull with the respective arg `--decryption-password`.
+
+```shell
+$ drive push --encryption-password "$400lsGO1Di3" few-ones.mp4 newest.mkv
+```
+
+```shell
+$ drive pull --decryption-password "$400lsGO1Di3" few-ones.mp4 newest.mkv
+```
+
+If you supply the wrong password, you'll be warned if it cannot be decrypted
+
+```shell
+$ drive pull --decryption-password "4nG5troM" few-ones.mp4 newest.mkv
+message corrupt or incorrect password
+```
+
+To pull normally push or pull your content, without attempting any *cryption attempts, skip
+passing in a password and no attempts will be made.
+
+
 
 ### Publishing
 

--- a/src/commands.go
+++ b/src/commands.go
@@ -16,6 +16,7 @@ package drive
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -92,6 +93,9 @@ type Options struct {
 	Destination                  string
 	RenameMode                   RenameMode
 	ExponentialBackoffRetryCount int
+
+	Encrypter func(io.Reader) (io.Reader, error)
+	Decrypter func(io.Reader) (io.ReadCloser, error)
 }
 
 type Commands struct {

--- a/src/help.go
+++ b/src/help.go
@@ -191,6 +191,8 @@ const (
 	DescSkipContentCheck             = "skip diffing actual body content, show only name, time, type changes"
 	DescPushDestination              = "specify the final destination of the contents of an operation"
 	DescExponentialBackoffRetryCount = "max number of retries for exponential backoff"
+	DescEncryptionPassword           = "encryption password"
+	DescDecryptionPassword           = "decryption password"
 )
 
 const (
@@ -234,6 +236,8 @@ const (
 	CLIOptionRenameLocal        = "local"
 	CLIOptionRenameRemote       = "remote"
 	CLIOptionRetryCount         = "retry-count"
+	CLIEncryptionPassword       = "encryption-password"
+	CLIDecryptionPassword       = "decryption-password"
 )
 
 const (

--- a/src/pull.go
+++ b/src/pull.go
@@ -90,6 +90,9 @@ func (g *Commands) PullMatchLike() error {
 }
 
 func pull(g *Commands, pt pullType) error {
+	g.rem.encrypter = g.opts.Encrypter
+	g.rem.decrypter = g.opts.Decrypter
+
 	cl, clashes, err := pullLikeResolve(g, pt)
 
 	if len(clashes) >= 1 {
@@ -273,6 +276,9 @@ func (g *Commands) pullLikeMatchesResolver(pt pullType) (cl, clashes []*Change, 
 }
 
 func (g *Commands) PullPiped(byId bool) (err error) {
+	g.rem.encrypter = g.opts.Encrypter
+	g.rem.decrypter = g.opts.Decrypter
+
 	resolver := g.rem.FindByPathM
 	if byId {
 		resolver = g.rem.FindByIdM

--- a/src/push.go
+++ b/src/push.go
@@ -35,6 +35,9 @@ var mkdirAllMu = sync.Mutex{}
 // directory, it recursively pushes to the remote if there are local changes.
 // It doesn't check if there are local changes if isForce is set.
 func (g *Commands) Push() (err error) {
+	g.rem.encrypter = g.opts.Encrypter
+	g.rem.decrypter = g.opts.Decrypter
+
 	defer g.clearMountPoints()
 
 	var cl []*Change
@@ -181,6 +184,9 @@ func (g *Commands) resolveConflicts(cl []*Change, push bool) (*[]*Change, *[]*Ch
 }
 
 func (g *Commands) PushPiped() (err error) {
+	g.rem.encrypter = g.opts.Encrypter
+	g.rem.decrypter = g.opts.Decrypter
+
 	// Cannot push asynchronously because the push order must be maintained
 	for _, relToRootPath := range g.opts.Sources {
 		rem, resErr := g.rem.FindByPath(relToRootPath)


### PR DESCRIPTION
Data should only be unencrypted on the user's local disk but
should always be encrypted remotely on Google Drive, if the
password was provided.

- When a password is provided, encrypt the data before it is received
by Google Drive. Encrypt for upload:
```shell
$ drive push --encryption-password foolsGold issueFilingDrive.mp4
```

- When a password is provided, decrypt the data before writing
it to disk:
```shell
$ drive pull --piped issueFilingDrive.mp4 --decryption-password
foolsGold > txt.v
```