### PR TITLE
E2E: Adjust the remote size when using encryption.

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/odeke-em/drive/config"
+	"github.com/odeke-em/drive/src/dcrypto"
 	"github.com/odeke-em/log"
 )
 
@@ -463,6 +464,11 @@ func (g *Commands) changeSlice(cslArg *changeSliceArg) {
 		// Avoiding path.Join which normalizes '/+' to '/'
 		localBase := remotePathJoin(cslArg.localParent, l.Name())
 		remoteBase := remotePathJoin(cslArg.remoteParent, l.Name())
+
+		nonDirRemote := l.remote != nil && !l.remote.IsDir
+		if nonDirRemote && g.opts.CryptoEnabled() {
+			l.remote.Size -= int64(dcrypto.Overhead)
+		}
 
 		clr := &changeListResolve{
 			push:       push,

--- a/src/commands.go
+++ b/src/commands.go
@@ -98,6 +98,10 @@ type Options struct {
 	Decrypter func(io.Reader) (io.ReadCloser, error)
 }
 
+func (opts *Options) CryptoEnabled() bool {
+	return opts.Decrypter != nil || opts.Encrypter != nil
+}
+
 type Commands struct {
 	context *config.Context
 	rem     *Remote

--- a/src/dcrypto/dcrypto.go
+++ b/src/dcrypto/dcrypto.go
@@ -55,6 +55,9 @@ var hashers map[Version]hasher
 // a hash of a local file.
 var MaxHeaderSize = v1.HeaderSize + 4
 
+// Overhead is the overhead added by the preferred encryption library plus the version.
+var Overhead = v1.Overhead + 4
+
 func init() {
 	decrypters = map[Version]decrypter{
 		V1: v1.NewDecryptReader,

--- a/src/dcrypto/v1/v1.go
+++ b/src/dcrypto/v1/v1.go
@@ -75,8 +75,8 @@ var (
 	HeaderSize = 4 + saltSize + blockSize
 
 	// The overhead added to the file by using this library.
-	// OverHead + len(plaintext) == len(ciphertext)
-	OverHead = HeaderSize + hmacSize
+	// Overhead + len(plaintext) == len(ciphertext)
+	Overhead = HeaderSize + hmacSize
 )
 
 var DecryptErr = errors.New("message corrupt or incorrect password")


### PR DESCRIPTION
This change allows the local and remote file sizes to match so
that push/pull can skip files. It does have the side effect that
if the user wanted to change the password they'd have to force.