### PR TITLE
version: bump to v0.3.7 for special release

### DIFF
--- a/src/about.go
+++ b/src/about.go
@@ -21,7 +21,7 @@ import (
 	drive "google.golang.org/api/drive/v2"
 )
 
-const Version = "0.3.6"
+const Version = "0.3.7"
 
 const (
 	Barely = iota


### PR DESCRIPTION
Bumping to v0.3.7 special release so that E2E Encryption
feature is the top release for everyone to use.