### PR TITLE
Makefile for cross compilation added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin/
+md5Sums.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+# Makefile for cross-compilation
+#
+OS := $(shell uname)
+BINDIR := ./bin
+MD5_TEXTFILE := $(BINDIR)/md5Sums.txt
+
+MAIN_FILE_DIR := ./cmd/drive
+
+ifeq ($(OS), Darwin)
+  MD5_UTIL = md5
+else
+  MD5_UTIL = md5sum
+endif
+
+all: compileThemAll md5SumThemAll
+
+compileThemAll: armv5 armv6 armv7 armv8 darwin linux
+
+md5SumThemAll:
+	rm -f $(MD5_TEXTFILE)
+	find $(BINDIR) -type f -name "drive_*" -exec $(MD5_UTIL) {} >> $(MD5_TEXTFILE) \;
+
+armv5:
+	CGO_ENABLED=0 GOOS=linux GOARM=5 GOARCH=arm go build -o $(BINDIR)/drive_armv5 $(MAIN_FILE_DIR)
+armv6:
+	CGO_ENABLED=0 GOOS=linux GOARM=6 GOARCH=arm go build -o $(BINDIR)/drive_armv6 $(MAIN_FILE_DIR)
+armv7:
+	CGO_ENABLED=0 GOOS=linux GOARM=7 GOARCH=arm go build -o $(BINDIR)/drive_armv7 $(MAIN_FILE_DIR)
+armv8:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(BINDIR)/drive_armv8 $(MAIN_FILE_DIR)
+darwin:
+	CGO_ENABLED=0 GOOS=darwin go build -o $(BINDIR)/drive_darwin $(MAIN_FILE_DIR)
+linux:
+	CGO_ENABLED=0 GOOS=linux go build -o $(BINDIR)/drive_linux $(MAIN_FILE_DIR)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Installation](#installation)
   - [Platform Packages](#platform-packages)
   - [Godep](#godep)
+  - [Cross Compilation](#cross-compilation)
 - [Configuration](#configuration)
 - [Usage](#usage)
   - [Initializing](#initializing)
@@ -131,6 +132,21 @@ Please see file `drive-gen/README.md` for more information.
 For curated packages on your favorite platform, please see file [Platform Packages.md](https://github.com/odeke-em/drive/blob/master/platform_packages.md).
 
 Is your platform missing a package? Feel free to prepare / contribute an installation package and then submit a PR to add it in.
+
+### Cross Compilation
+
+See file `Makefile` which currently supports cross compilation. Just run `make` and then inspect the binaries in directory `bin`.
+
+* Supported platforms to cross compile to:
+- ARMv5.
+- ARMv6.
+- ARMv7.
+- ARMv8.
+- Darwin (OS X).
+- Linux.
+
+Also inspect file `bin/md5Sums.txt` after the cross compilation.
+
 
 ## Configuration
 


### PR DESCRIPTION
Added a Makefile for cross compilation during releases and to
democratize compilation for users themselves.

Updates #662.