### PR TITLE
push/pull: files and directories type selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,15 @@ $ drive pull --starred --all --trashed # Pull all the starred files in the trash
 
 Like most commands [.driveignore](#driveignore) can be used to filter which files to pull.
 
+To selectively pull by type e.g file vs directory/folder, you can use flags
+- `files`
+- `directories`
+
+```shell
+$ drive pull --files a1/b2
+$ drive pull --directories tf1
+```
+
 ## Note: Checksum verification:
 
 * By default checksum-ing is turned off because it was deemed to be quite vigorous and unnecessary for most cases.
@@ -395,6 +404,15 @@ drive also supports pushing content piped from stdin which can be accomplished b
 
 ```shell
 $ drive push -piped path
+```
+
+To selectively push by type e.g file vs directory/folder, you can use flags
+- `files`
+- `directories`
+
+```shell
+$ drive push --files a1/b2
+$ drive push --directories tf1
 ```
 
 Like most commands [.driveignore](#driveignore) can be used to filter which files to push.

--- a/src/list.go
+++ b/src/list.go
@@ -21,18 +21,6 @@ import (
 	"github.com/odeke-em/log"
 )
 
-const (
-	InTrash = 1 << iota
-	Folder
-	Shared
-	Owners
-	Minimal
-	Starred
-	NonFolder
-	DiskUsageOnly
-	CurrentVersion
-)
-
 type attribute struct {
 	minimal       bool
 	mask          int
@@ -397,7 +385,7 @@ func (g *Commands) breadthFirst(travSt traversalSt, spin *playable) bool {
 
 	spin.play()
 
-	onlyFiles := (g.opts.TypeMask & NonFolder) != 0
+	onlyFiles := nonFolderExplicitly(g.opts.TypeMask)
 
 	iterCount := uint64(0)
 


### PR DESCRIPTION
push and pull now allow for selection of types
e.g only files, only directories using flags
`--files` or `--directories`.

#### Pull:
- Exhibit A: No type sifting/selection -- ordinary pull
```shell
 drive pull a1
Resolving...
- /test/a1
- /test/a1/b2
- /test/a1/b2/c3
- /test/a1/b2/c3/d4
- /test/a1/b2/c3/d4/e5
- /test/a1/b2/c3/test.txt
Deletion count 6
Proceed with the changes? [Y/n]:
```

- Exhibit B: only files
```shell
$ drive pull --files a1
Resolving...
- /test/a1/b2/c3/test.txt
Deletion count 1
Proceed with the changes? [Y/n]:
```

- Exhibit C: only directories
```shell
$ drive pull --directories a1
Resolving...
- /test/a1
- /test/a1/b2
- /test/a1/b2/c3
- /test/a1/b2/c3/d4
- /test/a1/b2/c3/d4/e5
Deletion count 5
Proceed with the changes? [Y/n]:
```

- Exhibit D: illogical state, both files and directories
```shell
$ drive pull --directories --files a1
cannot request for both file and folder
```

#### Push:
- Exhibit A: No type sifting/selection -- ordinary request
```shell
$ mkdir -p a1/b2/c3/d4/e5 && touch a1/b2/c3/test.txt
$ drive push a1
Resolving...
+ /test/a1
+ /test/a1/b2
+ /test/a1/b2/c3
+ /test/a1/b2/c3/d4
+ /test/a1/b2/c3/d4/e5
+ /test/a1/b2/c3/test.txt
Addition count 6
Proceed with the changes? [Y/n]:
```

- Exhibit B: only files
```shell
$ drive push --files a1
Resolving...
+ /test/a1/b2/c3/test.txt
Addition count 1
Proceed with the changes? [Y/n]:
```

- Exhibit C: only directories
```shell
$ drive push --directories a1
Resolving...
+ /test/a1
+ /test/a1/b2
+ /test/a1/b2/c3
+ /test/a1/b2/c3/d4
+ /test/a1/b2/c3/d4/e5
Addition count 5
Proceed with the changes? [Y/n]:
```

- Exhibit D: illogical state
```shell
$ drive push --directories --files a1
cannot request for both file and folder
```

Fixes https://github.com/odeke-em/drive/issues/670.