### PR TITLE
share: with-link to avoid public file indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,13 @@ $ drive share -emails drive-mailing-list@gmail.com -message "Here is the drive c
 $ drive share --emails developers@developers.devs --message "Developers, developers developers" --id 0fM9rt0Yc9RTPeHRfRHRRU0dIY97 0fM9rt0Yc9kJRPSTFNk9kSTVvb0U
 ```
 
++ You can also share a file to only those with the link. As per [https://github.com/odeke-em/drive/issues/568](https://github.com/odeke-em/drive/issues/568), this file won't be publicly indexed. To turn this option on when sharing the file,
+use flag `--with-link`.
+
+```shell
+$ drive share --with-link ComedyPunchlineDrumSound.mp3
+```
+
 ### Unsharing
 
 The `unshare` command revokes access of a specific accountType to a set of files.

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1440,6 +1440,7 @@ type shareCmd struct {
 	Notify      *bool   `json:"notify"`
 	Quiet       *bool   `json:"quiet"`
 	Verbose     *bool   `json:"verbose"`
+	WithLink    *bool   `json:"with-link"`
 }
 
 func (cmd *shareCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1448,6 +1449,7 @@ func (cmd *shareCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Role = fs.String(drive.RoleKey, "", "role to set to receipients of share. Possible values: "+drive.DescRoles)
 	cmd.AccountType = fs.String(drive.TypeKey, "", "scope of accounts to share files with. Possible values: "+drive.DescAccountTypes)
 	cmd.Notify = fs.Bool(drive.CLIOptionNotify, true, "toggle whether to notify receipients about share")
+	cmd.WithLink = fs.Bool(drive.CLIOptionWithLink, false, drive.DescWithLink)
 	cmd.NoPrompt = fs.Bool(drive.NoPromptKey, false, "disables the prompt")
 	cmd.Quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.ById = fs.Bool(drive.CLIOptionId, false, "share by id instead of path")
@@ -1468,7 +1470,10 @@ func (cmd *shareCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 
 	mask := drive.NoopOnShare
 	if *cmd.Notify {
-		mask = drive.Notify
+		mask |= drive.Notify
+	}
+	if *cmd.WithLink {
+		mask |= drive.WithLink
 	}
 
 	exitWithError(drive.New(context, &drive.Options{

--- a/src/help.go
+++ b/src/help.go
@@ -193,6 +193,7 @@ const (
 	DescExponentialBackoffRetryCount = "max number of retries for exponential backoff"
 	DescEncryptionPassword           = "encryption password"
 	DescDecryptionPassword           = "decryption password"
+	DescWithLink                     = "turn off file indexing so that only those with the link can view it"
 )
 
 const (
@@ -238,6 +239,7 @@ const (
 	CLIOptionRetryCount         = "retry-count"
 	CLIEncryptionPassword       = "encryption-password"
 	CLIDecryptionPassword       = "decryption-password"
+	CLIOptionWithLink           = "with-link"
 )
 
 const (

--- a/src/remote.go
+++ b/src/remote.go
@@ -400,8 +400,9 @@ func (r *Remote) listPermissions(id string) ([]*drive.Permission, error) {
 
 func (r *Remote) insertPermissions(permInfo *permission) (*drive.Permission, error) {
 	perm := &drive.Permission{
-		Role: permInfo.role.String(),
-		Type: permInfo.accountType.String(),
+		Role:     permInfo.role.String(),
+		Type:     permInfo.accountType.String(),
+		WithLink: permInfo.withLink,
 	}
 
 	if permInfo.value != "" {


### PR DESCRIPTION
Enables sharing to anyone with the link but the file won't be
publicly indexed as is usually with files that are published publicly.

```shell
$ drive share --with-link ComedyPunchlineDrumSound.mp3
```

Fixes https://github.com/odeke-em/drive/issues/568.
Follows suggestions in
https://github.com/odeke-em/drive/issues/650#issuecomment-222927083.