### PR TITLE
rc: fix err variable reuse

### DIFF
--- a/src/rc.go
+++ b/src/rc.go
@@ -198,7 +198,6 @@ func splitAndStrip(line string, resolveFromEnv bool) (kv keyValue, err error) {
 
 func JSONStringifySiftedCLITags(from interface{}, rcSourcePath string, defined map[string]bool) (string, error) {
 	rcMappings, err := ResourceMappings(rcSourcePath)
-
 	if err != nil && !NotExist(err) {
 		return "", err
 	}
@@ -209,5 +208,5 @@ func JSONStringifySiftedCLITags(from interface{}, rcSourcePath string, defined m
 		AlreadyDefined: defined,
 	}
 
-	return SiftCliTags(&cs), err
+	return SiftCliTags(&cs), nil
 }


### PR DESCRIPTION
In PR https://github.com/odeke-em/drive/pull/676,
I touched up the signature and content for function
`JSONStringifySiftedCLITags` to not use named return values.
However, I changed the error check from `ResourceMappings`
to just be `err`. The first check ensures that either a file
exists or doesn't exist. Reusing that variable at the end of
the function meant that any previous error checks for rc paths
that didn't exist were being returned and this would send
back os.ErrNotExist yet the intention of the function
is to digest this error as a check and not as a return value.

Fixes https://github.com/odeke-em/drive/issues/677.