### PR TITLE
src/changes: do not dereference nil filter

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -348,7 +348,7 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 
 	if change.Op() != OpNone {
 		subject := directionalComplement(l, r, clr.push)
-		if clr.filter(subject) {
+		if clr.filter == nil || clr.filter(subject) {
 			cl = append(cl, change)
 		}
 	}


### PR DESCRIPTION
Updates #681.

Fixes a crash introduced by PR 673, in which in cases that we were doing
`push -m`, we'd have nil filters, and dereferenced one.