### PR TITLE
rc: register encryption+decryption key variables

### DIFF
--- a/src/rc.go
+++ b/src/rc.go
@@ -105,6 +105,7 @@ func parseRCValues(rcMap map[string]string) (valueMappings map[string]interface{
 				CLIOptionUnified, CLIOptionDiffBaseLocal,
 				ExportsKey, ExcludeOpsKey, CLIOptionUnifiedShortKey,
 				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
+				CLIEncryptionPassword, CLIDecryptionPassword,
 			},
 		},
 		{


### PR DESCRIPTION
Resource configuration mappings now recognize keys
+ encryption-key
+ decryption-key

```shell
$ cat .driverc
hidden=true
encryption-password=bonjour
decryption-password=bonjour
$ drive push test.mp4 # Should be encrypted at rest
$ drive pull --piped test.mp4 > outf && diff outf test.mp4 # Should be decrypted properly
```

Fixes https://github.com/odeke-em/drive/issues/683.