### PR TITLE
pull/export: allow exporting to same directory+level

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,24 @@ By default, the exported files will be placed in a new directory suffixed by `\_
 $ drive pull -export pdf,rtf,docx,txt -export-dir ~/Desktop/exports
 ```
 
+Otherwise, you can export files to the same directory as requested in [issue #660](https://github.com/odeke-em/drive/issues/660),
+by using pull flag `--same-exports-dir`. For example:
+```shell
+ drive pull --explicitly-export --exports-dir ~/Desktop/exp --export pdf,txt,odt --same-exports-dir 
+Resolving...
++ /test-exports/few.docs
++ /test-exports/few
++ /test-exports/influx
+Addition count 3
+Proceed with the changes? [Y/n]:y
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx.pdf'
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx.txt'
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few' to '/Users/emmanuelodeke/Desktop/exp/few.pdf'
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.txt'
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.odt'
+Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.pdf'
+```
+
 **Supported formats:**
 
 * doc, docx

--- a/src/commands.go
+++ b/src/commands.go
@@ -41,6 +41,11 @@ type Options struct {
 	// ExportsDir is the directory to put the exported Google Docs + Sheets.
 	// If not provided, will export them to the same dir as the source files are
 	ExportsDir string
+
+	// ExportsDumpToSameDirectory when set, requests that all exports be put in the
+	// same directory instead of in a directory that is prefixed first by the file name
+	ExportsDumpToSameDirectory bool
+
 	// Force once set always converts NoChange into an Addition
 	Force bool
 	// Hidden discovers hidden paths if set

--- a/src/help.go
+++ b/src/help.go
@@ -240,6 +240,8 @@ const (
 	CLIEncryptionPassword       = "encryption-password"
 	CLIDecryptionPassword       = "decryption-password"
 	CLIOptionWithLink           = "with-link"
+
+	CLIOptionExportsDumpToSameDirectory = "same-exports-dir"
 )
 
 const (

--- a/src/pull.go
+++ b/src/pull.go
@@ -593,12 +593,19 @@ func touchFile(path string) (err error) {
 	return
 }
 
+func (g *Commands) makeExportsDir(segments ...string) string {
+	if !g.opts.ExportsDumpToSameDirectory {
+		segments = append(segments, "exports")
+	}
+	return sepJoin("_", segments...)
+}
+
 func (g *Commands) export(f *File, destAbsPath string, exports []string) (manifest []string, err error) {
 	if len(exports) < 1 || f == nil {
 		return
 	}
 
-	dirPath := sepJoin("_", destAbsPath, "exports")
+	dirPath := g.makeExportsDir(destAbsPath)
 	if err = os.MkdirAll(dirPath, os.ModeDir|0755); err != nil {
 		return
 	}
@@ -721,7 +728,11 @@ func (g *Commands) download(change *Change, exports []string) error {
 
 	exportDirPath := destAbsPath
 	if g.opts.ExportsDir != "" {
-		exportDirPath = path.Join(g.opts.ExportsDir, change.Src.Name)
+		if g.opts.ExportsDumpToSameDirectory {
+			exportDirPath = g.opts.ExportsDir
+		} else {
+			exportDirPath = path.Join(g.opts.ExportsDir, change.Src.Name)
+		}
 	}
 
 	manifest, exportErr := g.export(change.Src, exportDirPath, exports)


### PR DESCRIPTION
Fixes #660.

Allow exporting to same directory and level, instead of:
a) Always dumping exports per exportable file in a sub-directory
called `<filename>_exports`.
This CL allows for users to request that their exports be put in the
same directory with pull flag `--same-exports-dir`.
If `--same-exports-dir` is set, it will place all exports in the same
directory and level.

* Exhibit A:
```shell
 drive pull --explicitly-export --exports-dir ~/Desktop/exp --export
pdf,txt,odt --same-exports-dir
Resolving...
+ /test-exports/few.docs
+ /test-exports/few
+ /test-exports/influx
Addition count 3
Proceed with the changes? [Y/n]:y
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx.pdf'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx.txt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few' to '/Users/emmanuelodeke/Desktop/exp/few.pdf'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.txt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.odt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs.pdf'
```

* Exhibit B (Original case, _exports suffixed dirs used):
```shell
$ drive pull --explicitly-export --exports-dir ~/Desktop/exp --export
pdf,txt,odt
Resolving...
+ /test-exports/few.docs
+ /test-exports/few
+ /test-exports/influx
Addition count 3
Proceed with the changes? [Y/n]:y
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx_exports/influx.pdf'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/influx' to '/Users/emmanuelodeke/Desktop/exp/influx_exports/influx.txt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few' to '/Users/emmanuelodeke/Desktop/exp/few_exports/few.pdf'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs_exports/few.docs.odt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs_exports/few.docs.txt'
Exported '/Users/emmanuelodeke/emm.odeke@gmail.com/test-exports/few.docs' to '/Users/emmanuelodeke/Desktop/exp/few.docs_exports/few.docs.pdf'
```