### PR TITLE
pull: allow disabling of *.desktop file creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,13 @@ $ cat << $ >> ~/emm.odeke-drive/fall2015Classes/.driverc
 
 As previously mentioned, Google Docs, Drawings, Presentations, Sheets etc and all files affiliated
 with docs.google.com cannot be downloaded raw but only exported. Due to popular demand, Linux users
-desire the ability to have \*.desktop files that enable the file to be opened appropriately by an external opener. Thus by default on Linux, drive will create \*.desktop files for files that fall into this category.
+desire the ability to have \*.desktop files that enable the file to be opened appropriately by an external opener.
+Thus by default on Linux, drive will create \*.desktop files for files that fall into this category.
+
+To turn off this behavior, you can set flag `--desktop-links` to false e.g
+```shell
+$ drive pull --desktop-links=false
+```
 
 ## Command Aliases
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -644,6 +644,8 @@ type pullCmd struct {
 
 	ExponentialBackoffRetryCount *int  `json:"retry-count"`
 	ExportsDumpToSameDirectory   *bool `json:"same-exports-dir"`
+
+	AllowURLLinkedFiles *bool `json:"desktop-links"`
 }
 
 func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -679,6 +681,7 @@ func (cmd *pullCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 
 	cmd.Files = fs.Bool(drive.CLIOptionFiles, false, "pull only files")
 	cmd.Directories = fs.Bool(drive.CLIOptionDirectories, false, "pull only directories")
+	cmd.AllowURLLinkedFiles = fs.Bool(drive.CLIOptionDesktopLinks, true, drive.DescAllowDesktopLinks)
 
 	return fs
 }
@@ -764,6 +767,7 @@ func (pCmd *pullCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		ExplicitlyExport:  *cmd.ExplicitlyExport,
 		IgnoreNameClashes: *cmd.IgnoreNameClashes,
 
+		AllowURLLinkedFiles:          *cmd.AllowURLLinkedFiles,
 		ExportsDumpToSameDirectory:   *cmd.ExportsDumpToSameDirectory,
 		ExponentialBackoffRetryCount: retryCount,
 	}

--- a/src/commands.go
+++ b/src/commands.go
@@ -101,6 +101,12 @@ type Options struct {
 
 	Encrypter func(io.Reader) (io.Reader, error)
 	Decrypter func(io.Reader) (io.ReadCloser, error)
+
+	// AllowURLLinkedFiles when set signifies that the user
+	// depending on their OS, wants us to create for them
+	// clickable files where applicable.
+	// See issue #697.
+	AllowURLLinkedFiles bool
 }
 
 func (opts *Options) CryptoEnabled() bool {

--- a/src/help.go
+++ b/src/help.go
@@ -194,6 +194,7 @@ const (
 	DescEncryptionPassword           = "encryption password"
 	DescDecryptionPassword           = "decryption password"
 	DescWithLink                     = "turn off file indexing so that only those with the link can view it"
+	DescAllowDesktopLinks            = "allows docs + sheets to be pulled as .desktop files or URL linked files"
 )
 
 const (
@@ -240,6 +241,7 @@ const (
 	CLIEncryptionPassword       = "encryption-password"
 	CLIDecryptionPassword       = "decryption-password"
 	CLIOptionWithLink           = "with-link"
+	CLIOptionDesktopLinks       = "desktop-links"
 
 	CLIOptionExportsDumpToSameDirectory = "same-exports-dir"
 )

--- a/src/pull.go
+++ b/src/pull.go
@@ -681,6 +681,11 @@ func isLocalFile(f *File) bool {
 	return f != nil && f.Etag == ""
 }
 
+func (g *Commands) shouldCreateURLLinkedFiles() bool {
+	// TODO: Add the equivalents here for other OSes
+	return g.opts.AllowURLLinkedFiles && runtime.GOOS == OSLinuxKey
+}
+
 func (g *Commands) download(change *Change, exports []string) error {
 	if change.Src == nil {
 		return illogicalStateErr(fmt.Errorf("tried to download nil change.Src"))
@@ -703,8 +708,8 @@ func (g *Commands) download(change *Change, exports []string) error {
 		return err
 	}
 
-	// For our Linux kin that need .desktop files
-	if runtime.GOOS == OSLinuxKey {
+	// For our kin that need .desktop files
+	if g.shouldCreateURLLinkedFiles() {
 		f := change.Src
 
 		urlMExt := urlMimeTypeExt{


### PR DESCRIPTION
Fixes #697.

Users can now turn off *.desktop file creation by using flag
`--desktop-links` e.g
```shell
$ drive pull --desktop-links=false
```