### PR TITLE
push/mounted: fix unload of paths in root + no return catch

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -851,6 +851,7 @@ func (cmd *pushCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 func (cmd *pushCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	if *cmd.MountedPush {
 		exitWithError(cmd.pushMounted(args, definedFlags))
+		return
 	}
 
 	sources, context, path := preprocessArgs(args)
@@ -1056,7 +1057,7 @@ func (cmd *pushCmd) pushMounted(args []string, definedFlags map[string]*flag.Fla
 	// Expectation is that at least one path has to be passed in
 	if argc < 2 {
 		cwd, cerr := os.Getwd()
-		if cerr != nil {
+		if cerr == nil {
 			contextArgs = append(contextArgs, cwd)
 		}
 		rest = args


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/641.

+ Refactored push mounted, removing/generalizing code for
mounts to use same as ordinary pushes.

+ Ensure that in cmd/drive/main.go, after a mounted push
we return appropriately otherwise we were erraneously falling
to start an ordinary push which would trigger a bug with
a bad context. This is akin to the common C-style switch bug in which
one forgets to break/return.

+ Fixed up a bug with mounted push where if the user
specified a single mounted path, the current working
directory wouldn't be added to the arguments that needed
to be processed. It was an error comparison mismatch.