### PR TITLE
sort: fixed sorters to be split by comma

### DIFF
--- a/src/help.go
+++ b/src/help.go
@@ -163,7 +163,7 @@ const (
 		"\n\t* Are on a low power device"
 	DescIgnoreConflict               = "turns off the conflict resolution safety"
 	DescIgnoreNameClashes            = "ignore name clashes"
-	DescSort                         = "sort items in the order\n\t* md5.\n\t* name.\n\t* size.\n\t* type.\n\t* version"
+	DescSort                         = "sort items by a combination of attributes\n\t* modtime.\n\t* md5.\n\t* name.\n\t* size.\n\t* type.\n\t* version\ncomma separated e.g modtime,md5_r,name"
 	DescSkipMime                     = "skip elements with mimeTypes derived from these extensions"
 	DescMatchMime                    = "get elements with the exact mimeTypes derived from extensions"
 	DescMatchTitle                   = "elements with matching titles"

--- a/src/list.go
+++ b/src/list.go
@@ -39,17 +39,30 @@ type traversalSt struct {
 	matchQuery       *matchQuery
 }
 
-func sorters(opts *Options) (sortKeys []string) {
+func sorters(opts *Options) []string {
 	if opts == nil || opts.Meta == nil {
-		return
+		return nil
 	}
 
 	meta := *(opts.Meta)
 	retr, ok := meta[SortKey]
 	if !ok {
-		return
+		return nil
 	}
-	return retr
+
+	// Keys sent it via meta need to be comma split
+	// first, space trimmed then added.
+	// See Issue https://github.com/odeke-em/drive/issues/714.
+	var sortKeys []string
+	for _, attr := range retr {
+		splits := strings.Split(attr, ",")
+		for _, split := range splits {
+			trimmedAttr := strings.TrimSpace(split)
+			sortKeys = append(sortKeys, trimmedAttr)
+		}
+	}
+
+	return sortKeys
 }
 
 func (g *Commands) ListMatches() error {


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/714.

Sort attributes passed in from the commandline are csv values e.g
```shell
$ drive list -sort name_r,modtime
```

The bug previously was that these values were actually never getting
split by comma values, in cmd/drive/main. This CL ensures that we
do the necessary splitting and whitespace trimming before we
make the sorters.

It also updates the CLI doc on sort:
* Before
```shell
$ drive list -sort
  -sort string
      sort items in the order
  * md5.
  * name.
  * size.
  * type.
  * version
```

* After
```shell
$ drive list -sort
  -sort string
      sort items by a combination of attributes
  * modtime.
  * md5.
  * name.
  * size.
  * type.
  * version
```