### PR TITLE
Use API download instead of Drive Web Hosting

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -551,13 +551,8 @@ func (r *Remote) Download(id string, exportURL string) (io.ReadCloser, error) {
 	var url string
 	var body io.ReadCloser
 
-	if len(exportURL) < 1 {
-		url = DriveResourceHostURL + id
-	} else {
-		url = exportURL
-	}
+	resp, err := r.service.Files.Get(id).Download()
 
-	resp, err := r.client.Get(url)
 	if err == nil {
 		if resp == nil {
 			err = illogicalStateErr(fmt.Errorf("bug on: download for url \"%s\". resp and err are both nil", url))


### PR DESCRIPTION
Drive Web Hosting is being discontinued
(https://support.google.com/drive/answer/2881970?hl=en)