### PR TITLE
pull: ensure we can still pull exports

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -551,7 +551,14 @@ func (r *Remote) Download(id string, exportURL string) (io.ReadCloser, error) {
 	var url string
 	var body io.ReadCloser
 
-	resp, err := r.service.Files.Get(id).Download()
+	var resp *http.Response
+	var err error
+
+	if len(exportURL) < 1 {
+		resp, err = r.service.Files.Get(id).Download()
+	} else {
+		resp, err = r.client.Get(exportURL)
+	}
 
 	if err == nil {
 		if resp == nil {


### PR DESCRIPTION
Updates https://github.com/odeke-em/drive/pull/735.

Ensure that we can still pull exports after a body
fetch for exports was accidentally taken out.