### PR TITLE
version bump to v0.3.8!

### DIFF
--- a/src/about.go
+++ b/src/about.go
@@ -21,7 +21,7 @@ import (
 	drive "google.golang.org/api/drive/v2"
 )
 
-const Version = "0.3.7"
+const Version = "0.3.8"
 
 const (
 	Barely = iota


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/743.

Version bumped up to v0.3.8, new release.