### PR TITLE
share: fix regression in which emails were no longer being set

### DIFF
--- a/src/share.go
+++ b/src/share.go
@@ -398,6 +398,7 @@ func (c *Commands) share(revoke, byId bool) (err error) {
 		files:  files,
 		revoke: revoke,
 		roles:  roles,
+		emails: emails,
 
 		accountTypes: accountTypes,
 		emailMessage: emailMessage,


### PR DESCRIPTION
Ensures that we can still share files by emails

Fixes https://github.com/odeke-em/drive/issues/762.