### PR TITLE
list: pagination prompts only after each depth level of children

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -312,7 +312,7 @@ func _reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination, nilOn
 	filesChan := make(chan *File)
 	errsChan := make(chan error)
 
-	throttle := time.Tick(1e7)
+	throttle := time.Tick(1e8)
 
 	go func() {
 		defer func() {
@@ -349,8 +349,9 @@ func _reqDoPage(req *drive.FilesListCall, hidden bool, promptOnPagination, nilOn
 				break
 			}
 
+			<-throttle
+
 			if iterCount < 1 {
-				<-throttle
 				continue
 			}
 


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/724.

Fix print pagination prompts to only be done after
retrieving all the children within the same level
otherwise we get spurious prompts which is incorrect
behavior that doesn't match what pagination
is for.
Previously due to spurious prompts after every
single pagination within the same level, we'd
get prompts such as:
```shell
---More---
---More---
---More---
---More---
```
even before a single item was printed.

This change fixes that behavior.

The old behavior meant to alleviate problems with rate limits
but actually caused more problems and embarrasement for
printing than the remedy.
Anyways, we have a throttle of 1/10th of a second in place
between next pages.