### PR TITLE
handle differing dirTypes on direct addressing

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -372,7 +372,17 @@ func (g *Commands) resolveChangeListRecv(clr *changeListResolve) (cl, clashes []
 		return cl, clashes, nil
 	}
 
-	// TODO: handle cases where remote and local type don't match
+	// Let's handle the case where remote and local don't have
+	// the same dirType ie one is a file, the other is a directory.
+	// Note: This case currently is handled only when that
+	// specific object is directly addressed ie push <this> or pull <this>.
+	if l != nil && r != nil && !l.sameDirType(r) {
+		relPath := sepJoin("/", clr.remoteBase)
+		err := illogicalStateErr(fmt.Errorf("%s: local is a %v while remote is a %v",
+			relPath, l.dirTypeNomenclature(), r.dirTypeNomenclature()))
+		return cl, clashes, err
+	}
+
 	if !clr.push && r != nil && !r.IsDir {
 		return cl, clashes, nil
 	}

--- a/src/types.go
+++ b/src/types.go
@@ -225,6 +225,13 @@ func fauxLocalFile(relToRootPath string) *File {
 	}
 }
 
+func (f *File) dirTypeNomenclature() string {
+	if f.IsDir {
+		return "directory"
+	}
+	return "file"
+}
+
 func (f *File) Url() (url string) {
 	if f == nil {
 		return


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/769.

Handle the case where the local and remote objects
of a directly addressed path have different dirTypes ie
one is a regular file, the other is a directory/folder.
It returns an IllogicalStateError whose status can
be checked in the shell.

Fixes a TODO that has been waiting to be fixed.
Ensures that the case is caught e.g

* Exhibit:
```shell
$ drive new --mime-key docs share_test
$ mkdir -p share_test
$ drive pull share_test; echo $?
Resolving...
/share_test: local is a directory while remote is a file
8
```