### PR TITLE
fallback to counter.dest if the operation is a deletion

### DIFF
--- a/src/changes.go
+++ b/src/changes.go
@@ -73,6 +73,21 @@ func (t *sizeCounter) String() string {
 	return str
 }
 
+// There are operations for which the size of the target
+// is reported in the progress channel but absent for the
+// size counter for example OpDelete.
+// See Issue https://github.com/odeke-em/drive/issues/177.
+func (sc *sizeCounter) sizeByOperation(op Operation) int64 {
+	var size int64 = sc.src
+	switch op {
+	case OpDelete:
+		if sc.src == 0 && sc.dest > 0 {
+			size = sc.dest
+		}
+	}
+	return size
+}
+
 // Resolves the local path relative to the root directory
 // Returns the path relative to the remote, the abspath on disk and an error if any
 func (g *Commands) pathResolve() (relPath, absPath string, err error) {

--- a/src/pull.go
+++ b/src/pull.go
@@ -442,8 +442,8 @@ func (g *Commands) playPullChanges(cl []*Change, exports []string, opMap *map[Op
 	totalSize := int64(0)
 	ops := *opMap
 
-	for _, counter := range ops {
-		totalSize += counter.src
+	for op, counter := range ops {
+		totalSize += counter.sizeByOperation(op)
 	}
 
 	g.taskStart(totalSize)

--- a/src/push.go
+++ b/src/push.go
@@ -254,8 +254,8 @@ func (g *Commands) playPushChanges(cl []*Change, opMap *map[Operation]sizeCounte
 
 	totalSize := int64(0)
 	ops := *opMap
-	for _, counter := range ops {
-		totalSize += counter.src
+	for op, counter := range ops {
+		totalSize += counter.sizeByOperation(op)
 	}
 
 	g.taskStart(totalSize)


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/177.

For some operations such as OpDeletion counter.src == 0
yet counter.dest > 0.
Translation is if we are deleting a file, src == 0, yet dest > 0.

The mentioned condition would then mean that a 0 byte count
would be added to the expected progress counter. However, after
every successful operation the got progress channel would be
updated so X deleted bytes would be added to the got progress channel,
yet were not added to the expected progress channel, hence causing
overflows in the overall progress reports.