### PR TITLE
stat: recompose and propagate error instead of just logging it

### DIFF
--- a/src/misc.go
+++ b/src/misc.go
@@ -806,6 +806,19 @@ func combineErrors(prevErr, supplementaryErr error) error {
 	return newErr
 }
 
+// copyErrStatus copies the error status code from fromErr
+// to toErr only if toErr and fromErr are both non-nil.
+func copyErrStatusCode(toErr, fromErr error) error {
+	if toErr == nil || fromErr == nil {
+		return toErr
+	}
+	codedErr, hasCode := fromErr.(*Error)
+	if hasCode {
+		toErr = makeError(toErr, ErrorStatus(codedErr.Code()))
+	}
+	return toErr
+}
+
 func reComposeError(prevErr error, messages ...string) error {
 	if len(messages) < 1 {
 		return prevErr


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/801.

Recompose and propagate encountered errors along with their
status/run-level codes, instead of just logging them.

* Exhibit:
```shell
$ drive stat goos-goarch && echo "success"; echo $?
stat: /goos-goarch err: remote path doesn't exist
9
```