### PR TITLE
structured/sectioned .driverc configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1154,7 +1154,8 @@ drive <command> -h
 drive push -h
 ```
 
-and the value is the argument that you'd ordinarily supply on the commandline
+and the value is the argument that you'd ordinarily supply on the commandline.
+.driverc configurations can be optionally grouped in sections. See https://github.com/odeke-em/drive/issues/778.
 
 For example:
 
@@ -1164,6 +1165,20 @@ cat << ! >> ~/.driverc
 > exports=doc,pdf
 > depth=100
 > no-prompt=true
+>
+> # For pushes
+> [list]
+> depth=2
+> long=true
+>
+> [push]
+> verbose=false
+>
+> [stat]
+> depth=3
+>
+> [pull/push]
+> no-clobber=true
 > !
 
 cat << ! >> ~/emm.odeke-drive/.driverc

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -59,6 +59,7 @@ func translateKeyChecks(definedFlags map[string]*flag.Flag) map[string]bool {
 }
 
 type defaultsFiller struct {
+	command      string
 	from, to     interface{}
 	rcSourcePath string
 	definedFlags map[string]*flag.Flag
@@ -66,7 +67,7 @@ type defaultsFiller struct {
 
 func fillWithDefaults(df defaultsFiller) error {
 	alreadyDefined := translateKeyChecks(df.definedFlags)
-	jsonStringified, err := drive.JSONStringifySiftedCLITags(df.from, df.rcSourcePath, alreadyDefined)
+	jsonStringified, err := drive.JSONStringifySiftedCLITags(df.from, df.rcSourcePath, alreadyDefined, df.command)
 
 	if err != nil {
 		return err
@@ -352,7 +353,8 @@ func (lCmd *listCmd) _run(args []string, definedFlags map[string]*flag.Flag, dis
 	sources, context, path := preprocessArgsByToggle(args, (*lCmd.ById || *lCmd.Matches))
 	cmd := listCmd{}
 	df := defaultsFiller{
-		from: *lCmd, to: &cmd,
+		command: "list",
+		from:    *lCmd, to: &cmd,
 		rcSourcePath: context.AbsPathOf(path),
 		definedFlags: definedFlags,
 	}
@@ -690,7 +692,8 @@ func (pCmd *pullCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	sources, context, path := preprocessArgsByToggle(args, (*pCmd.ById || *pCmd.Matches || *pCmd.Starred))
 	cmd := pullCmd{}
 	df := defaultsFiller{
-		from: *pCmd, to: &cmd,
+		command: "pull",
+		from:    *pCmd, to: &cmd,
 		rcSourcePath: context.AbsPathOf(path),
 		definedFlags: definedFlags,
 	}
@@ -889,7 +892,8 @@ func (qCmd *qrLinkCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 
 	cmd := qrLinkCmd{}
 	df := defaultsFiller{
-		from: *qCmd, to: &cmd,
+		command: "qr",
+		from:    *qCmd, to: &cmd,
 		rcSourcePath: path,
 		definedFlags: definedFlags,
 	}
@@ -986,7 +990,8 @@ func exitIfIllogicalFileAndFolder(mask int) {
 func (pCmd *pushCmd) createPushOptions(absEntryPath string, definedFlags map[string]*flag.Flag) (*drive.Options, error) {
 	cmd := pushCmd{}
 	df := defaultsFiller{
-		from: *pCmd, to: &cmd,
+		command: "push",
+		from:    *pCmd, to: &cmd,
 		rcSourcePath: absEntryPath,
 		definedFlags: definedFlags,
 	}
@@ -1226,7 +1231,8 @@ func (uCmd *unpublishCmd) Run(args []string, definedFlags map[string]*flag.Flag)
 
 	cmd := unpublishCmd{}
 	df := defaultsFiller{
-		from: *uCmd, to: &cmd,
+		command: "unpublish",
+		from:    *uCmd, to: &cmd,
 		rcSourcePath: context.AbsPathOf(path),
 		definedFlags: definedFlags,
 	}
@@ -1700,7 +1706,8 @@ func (icmd *idCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	sources, context, path := preprocessArgs(args)
 	cmd := idCmd{}
 	df := defaultsFiller{
-		from: *icmd, to: &cmd,
+		command: "id",
+		from:    *icmd, to: &cmd,
 		rcSourcePath: context.AbsPathOf(path),
 		definedFlags: definedFlags,
 	}
@@ -1741,7 +1748,8 @@ func (ccmd *clashesCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 	sources, context, path := preprocessArgsByToggle(args, *ccmd.ById)
 	cmd := clashesCmd{}
 	df := defaultsFiller{
-		from: *ccmd, to: &cmd,
+		command: "clashes",
+		from:    *ccmd, to: &cmd,
 		rcSourcePath: context.AbsPathOf(path),
 		definedFlags: definedFlags,
 	}

--- a/src/misc.go
+++ b/src/misc.go
@@ -911,6 +911,8 @@ func SiftCliTags(cs *CliSifter) string {
 		switch elem.Kind() {
 		case reflect.String:
 			stringified = fmt.Sprintf("%q", elem)
+		case reflect.Invalid:
+			continue
 		default:
 			stringified = fmt.Sprintf("%v", elem.Interface())
 		}

--- a/src/rc_test.go
+++ b/src/rc_test.go
@@ -1,0 +1,142 @@
+package drive_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	drive "github.com/odeke-em/drive/src"
+)
+
+func TestStructuredRC(t *testing.T) {
+	tests := [...]struct {
+		rcDir   string
+		want    map[string]map[string]interface{}
+		wantErr bool
+	}{
+		0: {
+			rcDir: "./testdata/structured",
+			want: map[string]map[string]interface{}{
+				"global": {"depth": 10, "verbose": false},
+				"list":   {"long": true},
+				"push":   {"no-prompt": true},
+				"pull":   {"depth": 3, "no-prompt": false, "verbose": true},
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		rcMap, err := drive.ResourceMappings(tt.rcDir)
+
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: err=nil", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err=%v", i, err)
+			continue
+		}
+
+		// Not going to use reflect.DeepEqual because
+		// we've have trouble comparing any []string
+		gotBlob, _ := json.MarshalIndent(rcMap, "", "  ")
+		wantBlob, _ := json.MarshalIndent(tt.want, "", "  ")
+
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("#%d:\n\thave: %s\n\twant: %s", i, gotBlob, wantBlob)
+		}
+	}
+}
+
+type cliDefinition struct {
+	Depth    *int    `json:"depth"`
+	NoPrompt *bool   `json:"no-prompt"`
+	Verbose  *bool   `json:"verbose"`
+	Long     *bool   `json:"long"`
+	Sort     *string `json:"sort"`
+}
+
+func TestStructuredRCJSONSifting(t *testing.T) {
+	tests := [...]struct {
+		rcDir        string
+		wantErr      bool
+		relevantKeys []string
+		want         map[string]interface{}
+	}{
+		0: {
+			rcDir:        "./testdata/structured",
+			relevantKeys: []string{"push"},
+			want: map[string]interface{}{
+				"depth": 10, "verbose": false, "no-prompt": true,
+			},
+		},
+
+		1: {
+			rcDir:        "./testdata/structured",
+			relevantKeys: []string{"pull"},
+			want: map[string]interface{}{
+				"depth": 3, "verbose": true, "no-prompt": false,
+			},
+		},
+
+		// Since we aren't passing in any keys to get from,
+		// make sure we can still read from the global scope
+		2: {
+			rcDir:        "./testdata/structured",
+			relevantKeys: nil,
+			want: map[string]interface{}{
+				"depth":   10,
+				"verbose": false,
+			},
+		},
+
+		// Ensure that we can read from the
+		// old style, non-sectioned .driverc file.
+		3: {
+			rcDir:        "./testdata/non-sectioned",
+			relevantKeys: nil,
+			want: map[string]interface{}{
+				"depth":     10,
+				"verbose":   true,
+				"long":      true,
+				"no-prompt": false,
+				"sort":      "name,date_r",
+			},
+		},
+	}
+
+	for i, tt := range tests {
+		filler := cliDefinition{}
+		jsonStr, err := drive.JSONStringifySiftedCLITags(filler, tt.rcDir, nil, tt.relevantKeys...)
+
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("#%d: err=nil", i)
+			}
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("#%d: err=%v", i, err)
+			continue
+		}
+
+		saveMap := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(jsonStr), &saveMap); err != nil {
+			t.Errorf("#%d: err=%v", i, err)
+			continue
+		}
+
+		// Not going to use reflect.DeepEqual because
+		// we've have trouble comparing any []string
+		gotBlob, _ := json.MarshalIndent(saveMap, "", "  ")
+		wantBlob, _ := json.MarshalIndent(tt.want, "", "  ")
+
+		if !bytes.Equal(gotBlob, wantBlob) {
+			t.Errorf("#%d:\n\thave: %s\n\twant: %s", i, gotBlob, wantBlob)
+		}
+	}
+}

--- a/src/testdata/non-sectioned/.driverc
+++ b/src/testdata/non-sectioned/.driverc
@@ -1,0 +1,5 @@
+depth=10
+verbose=true
+long=true
+no-prompt=false
+sort=name,date_r

--- a/src/testdata/structured/.driverc
+++ b/src/testdata/structured/.driverc
@@ -1,0 +1,17 @@
+[global]
+depth=10
+verbose=false
+
+[push/pull]
+no-prompt=false
+
+[pull]
+depth=3
+verbose=true
+
+[push]
+# Last seen value overwrites in the same namespace
+no-prompt=true
+
+[list]
+long=true


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/778.

Now allows you to restructure your .driverc separating
commands into sections and having different clauses.

Please note:
* You can put multiple commands in the same
section by using separator "/". See the rules at
https://github.com/odeke-em/namespace/blob/0ab79ba44f1328b1ec75ea985ad5c338ba3d56a6/ns.go#L3-L14

* Overwriting of command rules is
command_section > global
and
commandX_higher_line > commandX_lower_line
where lines are natural numbers that are ascending

* Exhibits:
This is a sample of a .driverc that I've just defined that has flexible
behavior in different sections.

```
id=true # Will be applied globally unless overwritten in a command

[global]
depth=10 # The depth to use if not defined

[pull/list]
depth=2 # The depth to be used for pull or list

[push]
verbose=true # verbose is only true for push

[list]
long=true # Allow long output for list
```

And see the tests in src/rc_test.go that lock in the promised behavior.