### PR TITLE
command: introduce DebugPrintf

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -1311,6 +1311,7 @@ type trashCmd struct {
 	Matches *bool `json:"matches"`
 	Quiet   *bool `json:"quiet"`
 	ById    *bool `json:"by-id"`
+	Verbose *bool `json:"verbose"`
 }
 
 func (cmd *trashCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
@@ -1318,6 +1319,7 @@ func (cmd *trashCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.Matches = fs.Bool(drive.MatchesKey, false, "search by prefix and trash")
 	cmd.Quiet = fs.Bool(drive.QuietKey, false, "if set, do not log anything but errors")
 	cmd.ById = fs.Bool(drive.CLIOptionId, false, "trash by id instead of path")
+	cmd.Verbose = fs.Bool(drive.CLIOptionVerboseKey, false, drive.DescVerbose)
 
 	return fs
 }
@@ -1330,6 +1332,7 @@ func (cmd *trashCmd) Run(args []string, definedFlags map[string]*flag.Flag) {
 		Sources: sources,
 		Quiet:   *cmd.Quiet,
 		Match:   *cmd.Matches,
+		Verbose: *cmd.Verbose,
 	}
 
 	if !*cmd.Matches {
@@ -1849,7 +1852,9 @@ func initContext(args []string) *config.Context {
 
 func discoverContext(args []string) (*config.Context, string) {
 	var err error
-	context, err = config.Discover(getContextPath(args))
+	ctxPath := getContextPath(args)
+	context, err = config.Discover(ctxPath)
+	drive.DebugPrintf("contextPath: %q", ctxPath)
 	exitWithError(err)
 	relPath := ""
 	if len(args) > 0 {
@@ -1859,6 +1864,7 @@ func discoverContext(args []string) (*config.Context, string) {
 			relPath, err = filepath.Rel(context.AbsPath, headAbsArg)
 		}
 	}
+	drive.DebugPrintf("driveRoot: %q relToRoot: %q\n\n", context.AbsPath, relPath)
 
 	exitWithError(err)
 

--- a/src/changes.go
+++ b/src/changes.go
@@ -183,6 +183,7 @@ func (g *Commands) changeListResolve(relToRoot, fsPath string, push bool) (cl, c
 				iterCount++
 			}
 
+			g.DebugPrintf("[changeListResolve] relToRoot: %s remoteFile: %#v isPush: %v\n", relToRoot, rem, push)
 			ccl, cclashes, cErr := g.byRemoteResolve(relToRoot, fsPath, rem, push)
 
 			cl = append(cl, ccl...)

--- a/src/commands.go
+++ b/src/commands.go
@@ -135,6 +135,13 @@ func (opts *Options) canPrompt() bool {
 	return !opts.NoPrompt
 }
 
+func (c *Commands) DebugPrintf(fmt_ string, args ...interface{}) {
+	if !((Debug() || c.opts.Verbose) && c.opts.canPreview()) {
+		return
+	}
+	FDebugPrintf(c.log, fmt_, args...)
+}
+
 func (opts *Options) canPreview() bool {
 	if opts == nil || !opts.StdoutIsTty {
 		return false

--- a/src/list.go
+++ b/src/list.go
@@ -198,8 +198,9 @@ func (g *Commands) List(byId bool) error {
 
 	mq := g.createMatchQuery(true)
 
-	for _, relPath := range g.opts.Sources {
+	for i, relPath := range g.opts.Sources {
 		r, rErr := resolver(relPath)
+		g.DebugPrintf("[Commands.List] #%d %q\n", i, relPath)
 		if rErr != nil && rErr != ErrPathNotExists {
 			return illogicalStateErr(fmt.Errorf("%v: '%s'", rErr, relPath))
 		}

--- a/src/misc.go
+++ b/src/misc.go
@@ -1161,3 +1161,35 @@ func parseDurationOffsetFromNow(durationOffsetStr string) (*time.Time, error) {
 	offsetFromNow := time.Now().Add(d)
 	return &offsetFromNow, nil
 }
+
+// Debug returns true if DEBUG is set in the environment.
+// Set it to anything non-empty, for example `DEBUG=true`.
+func Debug() bool {
+	return os.Getenv("DEBUG") != ""
+}
+
+func DebugPrintf(fmt_ string, args ...interface{}) {
+	FDebugPrintf(os.Stdout, fmt_, args...)
+}
+
+// FDebugPrintf will only print output to the out writer if
+// environment variable `DEBUG` is set. It prints out a header
+// on a newline containing the introspection of the callsite,
+// and then the formatted message you'd like,
+// appending an obligatory newline at the end.
+// The output will be of the form:
+// [<FILE>:<FUNCTION>:<LINE_NUMBER>]
+// <MSG>\n
+func FDebugPrintf(f io.Writer, fmt_ string, args ...interface{}) {
+	if !Debug() {
+		return
+	}
+	if f == nil {
+		f = os.Stdout
+	}
+
+	programCounter, file, line, _ := runtime.Caller(2)
+	fn := runtime.FuncForPC(programCounter)
+	prefix := fmt.Sprintf("[\033[32m%s:%s:\033[33m%d\033[00m]\n%s\n", file, fn.Name(), line, fmt_)
+	fmt.Fprintf(f, prefix, args...)
+}

--- a/src/rc.go
+++ b/src/rc.go
@@ -15,6 +15,7 @@
 package drive
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -84,9 +85,11 @@ func ResourceMappings(rcPath string) (map[string]map[string]interface{}, error) 
 	rcPath, rcErr := beginOpts.rcPath()
 
 	if rcErr != nil {
+		DebugPrintf("tried to read from rcPath: %s got err: %v", rcPath, rcErr)
 		return nil, rcErr
 	}
 
+	DebugPrintf("RCPath: %s", rcPath)
 	nsRCMap, rErr := kvifyCommentedFile(rcPath, CommentStr)
 	if rErr != nil {
 		return nil, rErr
@@ -99,6 +102,12 @@ func ResourceMappings(rcPath string) (map[string]map[string]interface{}, error) 
 			return nil, err
 		}
 		grouped[key] = parsed
+	}
+
+	if jsonRepr, err := json.MarshalIndent(grouped, "", "  "); err == nil {
+		DebugPrintf("parsedContent from %q\n%s", rcPath, jsonRepr)
+	} else {
+		DebugPrintf("parsedContent from %q\n%s", rcPath, grouped)
 	}
 
 	return grouped, nil

--- a/src/trash.go
+++ b/src/trash.go
@@ -210,8 +210,9 @@ func (g *Commands) DeleteByMatch() error {
 
 func (g *Commands) reduceForTrash(args []string, opt *trashOpt) error {
 	var cl []*Change
-	for _, relToRoot := range args {
+	for i, relToRoot := range args {
 		c, cErr := g.trasher(relToRoot, opt)
+		g.DebugPrintf("[reduceForTrash] #%d: relToRoot: %s\n", i, relToRoot)
 		if cErr != nil {
 			g.log.LogErrf("\033[91m'%s': %v\033[00m\n", relToRoot, cErr)
 		} else if c != nil {
@@ -248,14 +249,18 @@ func (g *Commands) playTrashChangeList(cl []*Change, opt *trashOpt) (err error) 
 	var fn func(*Change) error
 	if opt.permanent {
 		fn = g.remoteDelete
+		g.DebugPrintf("[playTrashChangeList] isPermanentOp. Selecting remoteDelete\n")
 	} else {
 		fn = g.remoteUntrash
 		if opt.toTrash {
 			fn = g.remoteTrash
 		}
+		g.DebugPrintf("[playTrashChangeList/nonPermanentOp]: toTrash: %v\n", opt.toTrash)
 	}
 
-	for _, c := range cl {
+	for i, c := range cl {
+		op := c.Op()
+		g.DebugPrintf("[playTrashChangeList] #%d op: %v change: %#v\n", i, op, c)
 		if c.Op() == OpNone {
 			continue
 		}


### PR DESCRIPTION
Introduce DebugPrintf which can be used to give
contextual and debug information when things go wrong
and we need to observe them, when verbose or `DEBUG=true`
is set in the environment.

So far added debugging prints when parsing the .driverc file.
It prints out the:
[<FILE>:<FUNCTION>:<LINE_NUMBER>]

Prefix a drive invocation with `DEBUG=true`
```shell
$ DEBUG=true drive list share-testing/
[/Users/emmanuelodeke/go/src/github.com/odeke-em/drive/cmd/drive/main.go:main.discoverContext:1857]
contextPath: /Users/emmanuelodeke/emm.odeke@gmail.com/share-testing
[/Users/emmanuelodeke/go/src/github.com/odeke-em/drive/cmd/drive/main.go:main.discoverContext:1867]
driveRoot: "/Users/emmanuelodeke/emm.odeke@gmail.com" relToRoot: ""

[/Users/emmanuelodeke/go/src/github.com/odeke-em/drive/src/rc.go:github.com/odeke-em/drive/src.ResourceMappings:92]
RCPath: /Users/emmanuelodeke/emm.odeke@gmail.com/share-testing/.driverc
[/Users/emmanuelodeke/go/src/github.com/odeke-em/drive/src/rc.go:github.com/odeke-em/drive/src.ResourceMappings:108]
parsedContent from
"/Users/emmanuelodeke/emm.odeke@gmail.com/share-testing/.driverc"
{
  "global": {
    "depth": -1
  }
}
[Commands.List] #0 "/share-testing"
-- owner       175.00B	  0Bwu8laYc9RTPa28zVk9Td2hTVWc	  2016-06-30
15:32:25 +0000 UTC  /share-testing/SciqPCKrhi.go
-- owner       309.00B	  0Bwu8laYc9RTPTXRYblNqQXBSQzQ	  2016-02-03
08:12:15 +0000 UTC  /share-testing/outf.go
-s owner       39.70KB	  0Bwu8laYc9RTPOVNSeElpdFBpS2M	  2012-02-02
12:00:00 +0000 UTC  /share-testing/ComedyPunchlineDrumSound.mp3
```

It will alleviate https://github.com/odeke-em/drive/issues/829
since the reporter could then investigate and see the .gd path and
.driverc paths that were being read from.