### PR TITLE
stat/md5: allow op on depth=0 for dir children

### DIFF
--- a/src/stat.go
+++ b/src/stat.go
@@ -133,10 +133,6 @@ func prettyFileStat(logf log.Loggerf, relToRootPath string, file *File) {
 }
 
 func (g *Commands) stat(relToRootPath string, file *File, depth int) error {
-	if depth == 0 {
-		return nil
-	}
-
 	if g.opts.Md5sum {
 		if file.Md5Checksum != "" {
 			g.log.Logf("%32s  %s\n", file.Md5Checksum, strings.TrimPrefix(relToRootPath, "/"))
@@ -151,6 +147,10 @@ func (g *Commands) stat(relToRootPath string, file *File, depth int) error {
 		for _, perm := range perms {
 			prettyPermission(g.log.Logf, perm)
 		}
+	}
+
+	if depth == 0 {
+		return nil
 	}
 
 	if !file.IsDir {


### PR DESCRIPTION
Fixes https://github.com/odeke-em/drive/issues/783.

Ensures that for a directory, after decrementing the depth
by 1 in the parent's first pass that we at least operate on
passed in files instead of erraneously ending on that depth.
Traversal depth is meant for traversing directories/folders
and less on actual files.

This change leads us to conform to the proper behavior exhibited
by  `drive list`.