### PR TITLE
pull/push: allow fix-mode selection

### DIFF
--- a/src/clashes.go
+++ b/src/clashes.go
@@ -63,12 +63,21 @@ func (g *Commands) FixClashes(byId bool) error {
 		return err
 	}
 
+	fn := g.opts.clashesHandler()
+	return fn(g, clashes)
+}
+
+type clashesHandler func(g *Commands, clashes []*Change) error
+
+// clashesHandler returns the appropriate clashes handler depending
+// on the FixMode ie whether renaming or trashing is to be done.
+func (opts *Options) clashesHandler() clashesHandler {
 	fn := autoRenameClashes
-	if g.opts.FixClashesMode == FixClashesTrash {
+	if opts.FixClashesMode == FixClashesTrash {
 		fn = autoTrashClashes
 	}
 
-	return fn(g, clashes)
+	return fn
 }
 
 func findClashesForChildren(g *Commands, parentId, relToRootPath string, depth int) (clashes []*Change, err error) {

--- a/src/pull.go
+++ b/src/pull.go
@@ -101,7 +101,8 @@ func pull(g *Commands, pt pullType) error {
 			warnClashesPersist(g.log, clashes)
 			return ErrClashesDetected
 		} else {
-			err := autoRenameClashes(g, clashes)
+			fn := g.opts.clashesHandler()
+			err := fn(g, clashes)
 			if err == nil {
 				return clashesFixedErr(errors.New(MsgClashesFixedNowRetry))
 			}

--- a/src/push.go
+++ b/src/push.go
@@ -94,7 +94,8 @@ func (g *Commands) Push() error {
 
 	if len(clashes) >= 1 {
 		if g.opts.FixClashes {
-			err := autoRenameClashes(g, clashes)
+			fn := g.opts.clashesHandler()
+			err := fn(g, clashes)
 			if err == nil {
 				g.log.Logln(MsgClashesFixedNowRetry)
 			}


### PR DESCRIPTION
Fixes #836.

pull and push now have `-fix-mode` as an option to allow selecting
either "rename" or "trash" as the action to perform on fixing clashes.

```shell
$ drive push -fix-clashes -fix-mode trash a1 notes
$ drive pull -fix-clashes -fix-mode rename 2016 patents
```