### PR TITLE
README: bump minimum Go version to 1.7.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - 1.5
+  - 1.7
   - tip
 install:
   - go get -t ./...

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ## Requirements
 
-go 1.5.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
+go 1.7.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
 
 * Make sure to set your GOPATH in your env, .bashrc or .bash\_profile file. If you have not yet set it, you can do so like this:
 


### PR DESCRIPTION
Fixes #852.
Fixes #853.
Fixes #854.

Set the minimum Go version to 1.7.X.
Most of the Go versions below go1.7 are no longer even
supported. It is better to have the latest and greatest
with new features and more good things.