### PR TITLE
version bump to v0.3.9.1 to refresh PPA builds

### DIFF
--- a/src/about.go
+++ b/src/about.go
@@ -21,7 +21,7 @@ import (
 	drive "google.golang.org/api/drive/v2"
 )
 
-const Version = "0.3.9"
+const Version = "0.3.9.1"
 
 const (
 	Barely = iota


### PR DESCRIPTION
Updates
https://github.com/odeke-em/drive/pull/855#issuecomment-274678597.

Bump up the version by a minor point so that PPA builds can
be refreshed and built with at least go1.7.