### PR TITLE
Add QuotaBytesUsed to stat output

### DIFF
--- a/src/stat.go
+++ b/src/stat.go
@@ -92,6 +92,7 @@ func prettyFileStat(logf log.Loggerf, relToRootPath string, file *File) {
 		&keyValue{"FileId", file.Id},
 		&keyValue{"Bytes", fmt.Sprintf("%v", file.Size)},
 		&keyValue{"Size", prettyBytes(file.Size)},
+		&keyValue{"QuotaBytesUsed", fmt.Sprintf("%v", file.QuotaBytesUsed)},
 		&keyValue{"DirType", dirType},
 		&keyValue{"VersionNumber", fmt.Sprintf("%v", file.Version)},
 		&keyValue{"MimeType", file.MimeType},

--- a/src/types.go
+++ b/src/types.go
@@ -115,6 +115,7 @@ type File struct {
 	Labels                *drive.FileLabels
 	Description           string
 	Parents               []*ParentFile
+	QuotaBytesUsed        int64
 }
 
 func newParentFile(p *drive.ParentReference) *ParentFile {
@@ -166,6 +167,7 @@ func NewRemoteFile(f *drive.File) *File {
 		Labels:                f.Labels,
 		Description:           f.Description,
 		Parents:               parents,
+		QuotaBytesUsed:	       f.QuotaBytesUsed,
 	}
 }
 
@@ -198,6 +200,7 @@ func DupFile(f *File) *File {
 		OriginalFilename:   f.OriginalFilename,
 		Description:        f.Description,
 		Parents:            f.Parents,
+		QuotaBytesUsed:	       f.QuotaBytesUsed,
 	}
 }
 


### PR DESCRIPTION
Resolves enhancement request #849
Adds a line showing the QuotaBytesUsed  to the output of the stat command          

e.g.
```
.
.
Bytes                     1166863
Size                      1.11MB
QuotaBytesUsed            1166863
DirType                   file
VersionNumber             5403
MimeType                  application/pdf

.
.
```

or for a high quality image:
```
.
.
Bytes                     1972143
Size                      1.88MB
QuotaBytesUsed            0
DirType                   file
VersionNumber             541010
MimeType                  image/jpeg
.
.
```
