### PR TITLE
Ubuntu snap for drive

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/odeke-em/drive/
+github.com/odeke-em/drive/cmd/drive

--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/odeke-em/drive
+github.com/odeke-em/drive/cmd/drive

--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/odeke-em/drive/cmd/drive
+github.com/odeke-em/drive

--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/odeke-em/drive
+github.com/odeke-em/drive/

--- a/.godir
+++ b/.godir
@@ -1,1 +1,0 @@
-github.com/odeke-em/drive/cmd/drive

--- a/.godir
+++ b/.godir
@@ -1,1 +1,1 @@
-github.com/odeke-em/drive/tree/master/drive-gen
+github.com/odeke-em/drive

--- a/.godir
+++ b/.godir
@@ -1,0 +1,1 @@
+github.com/odeke-em/drive/tree/master/drive-gen

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -1,4 +1,3 @@
-before:
-- go get -u github.com/odeke-em/drive/cmd/drive
-- cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
-- cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore
+dependencies:
+  - default-dependency-1
+  - default-dependency-2

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -2,7 +2,4 @@ dependencies:
   - default-dependency-1
   - default-dependency-2
 before:
- - go get -u github.com/odeke-em/drive/cmd/drive
- - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
- - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore
-
+ - go get -u -v github.com/odeke-em/drive/drive-gen && drive-gen drive-google 

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -1,0 +1,4 @@
+before:
+- go get -u github.com/odeke-em/drive/cmd/drive
+- cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
+- cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -1,3 +1,8 @@
 dependencies:
   - default-dependency-1
   - default-dependency-2
+before:
+ - go get -u github.com/odeke-em/drive/cmd/drive
+ - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
+ - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore
+

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -2,5 +2,6 @@ dependencies:
   - default-dependency-1
   - default-dependency-2
 before:
- - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
- - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore
+ -  go get github.com/odeke-em/drive/cmd/drive
+ -	go get github.com/odeke-em/drive/config
+ -	go get github.com/odeke-em/command

--- a/.pkgr.yaml
+++ b/.pkgr.yaml
@@ -2,4 +2,5 @@ dependencies:
   - default-dependency-1
   - default-dependency-2
 before:
- - go get -u -v github.com/odeke-em/drive/drive-gen && drive-gen drive-google 
+ - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep save
+ - cd $GOPATH/src/github.com/odeke-em/drive/drive-gen && godep restore

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,20 @@
+name: drive
+version: 0.3.9
+summary: Google Drive client for the commandline
+description:
+  drive is a tiny program to pull or push Google Drive files.
+confinement: strict
+grade: stable
+
+apps:
+  drive:
+    command: bin/drive
+    plugs: [home, network, network-bind]
+
+parts:
+  drive:
+    plugin: go
+    source: https://github.com/odeke-em/drive
+    source-type: git
+    go-importpath: github.com/odeke-em/drive
+    build-packages: [gcc, libgudev-1.0-dev]


### PR DESCRIPTION
Hi odeke-em

i wanted to make it easier for people to install drive on different types of Linux distros, so i went ahead an setup an Ubuntu snap for drive, you can install drive by doing the following command. luckily snaps can be deployed on other distros as well such as Redhat, CentOS, Debian etc. currently i have my launchpad account pulling from my fork automatically using git and building an new snap each time i change something. so once you add my snapcraft.yaml file to the main repo for drive, i can change my launchpad settings to grab any changes automatically and push an new snap.

https://github.com/Dedsec1/drive/

https://github.com/Dedsec1/drive/blob/master/snapcraft.yaml

sudo snap install drive --classic

Regards

Dedsec1