### PR TITLE
.driverc parsing: recognize more CLI arguments/keys

### DIFF
--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -352,7 +352,7 @@ func (cmd *listCmd) Flags(fs *flag.FlagSet) *flag.FlagSet {
 	cmd.LongFmt = fs.Bool(drive.CLIOptionLongFmt, false, "long listing of contents")
 	cmd.PageSize = fs.Int64(drive.PageSizeKey, 100, "number of results per pagination")
 	cmd.Shared = fs.Bool("shared", false, "show files that are shared with me")
-	cmd.InTrash = fs.Bool(drive.TrashedKey, false, "list content in the trash")
+	cmd.InTrash = fs.Bool(drive.CLIOptionTrashed, false, "list content in the trash")
 	cmd.Version = fs.Bool("version", false, "show the number of times that the file has been modified on \n\t\tthe server even with changes not visible to the user")
 	cmd.NoPrompt = fs.Bool(drive.NoPromptKey, false, "shows no prompt before pagination")
 	cmd.Owners = fs.Bool("owners", false, "shows the owner names per file")

--- a/src/help.go
+++ b/src/help.go
@@ -258,6 +258,8 @@ const (
 	CLIOptionUploadChunkSize = "upload-chunk-size"
 
 	CLIOptionExportsDumpToSameDirectory = "same-exports-dir"
+
+	CLIOptionTrashed = TrashedKey
 )
 
 const (

--- a/src/rc.go
+++ b/src/rc.go
@@ -126,21 +126,26 @@ func parseRCValues(rcMap map[string]string) (valueMappings map[string]interface{
 				CLIOptionVerboseKey, RecursiveKey, CLIOptionFiles, CLIOptionLongFmt,
 				ForceKey, QuietKey, HiddenKey, NoPromptKey, NoClobberKey, IgnoreConflictKey,
 				CLIOptionIgnoreNameClashes, CLIOptionIgnoreChecksum, CLIOptionFixClashesKey,
-				CLIOptionDesktopLinks,
+				CLIOptionDesktopLinks, CLIOptionExportsDumpToSameDirectory, CLIOptionTrashed,
+				CLIOptionStarred, CLIOptionPiped, CLIOptionExplicitlyExport,
+				CLIOptionDirectories, CLIOptionAllStarred,
 			},
 		},
 		{
 			resolver: _intfer, keys: []string{
 				PageSizeKey,
 				DepthKey,
+				CLIOptionRetryCount,
 			},
 		},
 		{
 			resolver: _stringfer, keys: []string{
 				CLIOptionUnified, CLIOptionDiffBaseLocal,
 				ExportsKey, ExcludeOpsKey, CLIOptionUnifiedShortKey,
-				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
 				CLIEncryptionPassword, CLIDecryptionPassword, SortKey,
+				CLIOptionNotOwner, ExportsDirKey, CLIOptionExactTitle, AddressKey,
+				CLIOptionPushDestination, CLIOptionSkipMime, CLIOptionMatchMime,
+				ExportsKey,
 			},
 		},
 		{

--- a/src/rc_test.go
+++ b/src/rc_test.go
@@ -28,8 +28,13 @@ func TestStructuredRC(t *testing.T) {
 			rcDir: "./testdata/zero-values",
 			want: map[string]map[string]interface{}{
 				"global": {"force": true, "verbose": true},
-				"pull":   {"desktop-links": false, "force": true, "verbose": false},
-				"open":   {"verbose": true, "file-browser": false, "export": ""},
+				"pull": {
+					"desktop-links": false, "force": true, "verbose": false,
+					"export": "pdf,doc,rtf", "same-exports-dir": true,
+				},
+				"open":    {"verbose": true, "file-browser": false, "export": ""},
+				"push":    {"trashed": true, "retry-count": 10, "destination": "/tmp"},
+				"starred": {"all": true},
 			},
 		},
 	}

--- a/src/testdata/zero-values/.driverc
+++ b/src/testdata/zero-values/.driverc
@@ -6,8 +6,18 @@ verbose=true
 force=true
 verbose=false
 desktop-links=false
+export=pdf,doc,rtf
+same-exports-dir=true
 
 [open]
 file-browser=false
 export=
 verbose=true
+
+[push]
+trashed=true
+retry-count=10
+destination=/tmp
+
+[starred]
+all=true


### PR DESCRIPTION
Fixes #891.
Updates #906.

.driverc parsing should recognize more keys that are used
as command line arguments to different commands.

[Batcall to other contributors]: Please send PRs adding
missing keys, thank you!