### PR TITLE
Fix Windows filename issue, update Y/n Prompt, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1420,8 +1420,6 @@ Background sync is not just hard, it is stupid. Here are my technical and philos
 
 ## Known Issues
 
-* It probably doesn't work on Windows.
-* Google Drive allows a directory to contain files/directories with the same name. Client doesn't handle these cases yet. We don't recommend you to use `drive` if you have such files/directories to avoid data loss.
 * Racing conditions occur if remote is being modified while we're trying to update the file. Google Drive provides resource versioning with ETags, use Etags to avoid racy cases.
 * drive rejects reading from namedPipes because they could infinitely hang. See [issue #208](https://github.com/odeke-em/drive/issues/208).
 

--- a/cmd/drive/main.go
+++ b/cmd/drive/main.go
@@ -2057,6 +2057,10 @@ func relativePathsOpt(root string, args []string, leastNonExistant bool) ([]stri
 			relPath = ""
 		}
 
+		// This function appears to be meant to return server-side (/-separated) paths.
+		// But its input is client side (maybe / or \) separted paths.
+		// filepath.ToSlash fixes that.
+		relPath = filepath.ToSlash(relPath)
 		relPath = "/" + relPath
 		relPaths = append(relPaths, relPath)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -299,7 +299,7 @@ func (c *Context) DeInitialize(prompter func(...interface{}) bool, returnOnAnyEr
 	}
 
 	for _, p := range pathsToRemove {
-		if !prompter("remove: ", p, ". This operation is permanent (Y/N) ") {
+		if !prompter("remove: ", p, ". This operation is permanent (Y/n) ") {
 			continue
 		}
 

--- a/src/clashes.go
+++ b/src/clashes.go
@@ -274,7 +274,7 @@ func autoRenameClashes(g *Commands, clashes []*Change) error {
 		for _, r := range renames {
 			g.log.Logf("%v %v -> %v\n", r.originalPath, r.change.Src.Id, r.newName)
 		}
-		status := promptForChanges("Proceed with the changes [Y/N] ? ")
+		status := promptForChanges("Proceed with the changes [Y/n] ? ")
 		if !accepted(status) {
 			return ErrClashFixingAborted
 		}

--- a/src/trash.go
+++ b/src/trash.go
@@ -234,7 +234,7 @@ func (g *Commands) reduceForTrash(args []string, opt *trashOpt) error {
 	}
 
 	if opt.permanent && g.opts.canPrompt() {
-		status := promptForChanges("This operation is irreversible. Continue [Y/N] ")
+		status := promptForChanges("This operation is irreversible. Continue [Y/n] ")
 		if !accepted(status) {
 			return status.Error()
 		}


### PR DESCRIPTION
This request contains three independent changes.
* A bug fix for Windows, issue #917  . Uses the correct slash.
* Removed notes in the Readme about known issues which are fixed. This one (Windows) and also clashes are now at least somewhat handled (as described in issue #680 and perhaps elsewhere).
* Updated all the Y/N prompts I could find to reflect that it's really a Y/n prompt.