### PR TITLE
changes: properly send back nil if no file is found

### DIFF
--- a/src/remote.go
+++ b/src/remote.go
@@ -1096,8 +1096,14 @@ func (r *Remote) findByPathRecvRawM(parentId string, p []string, trashed bool) *
 					working = false
 					break
 				}
+
 				if f != nil {
 					chanOChan <- r.findByPathRecvRawM(f.Id, rest, trashed)
+				} else {
+					// Ensure that we properly send
+					// back nil even if files were not found.
+					// See https://github.com/odeke-em/drive/issues/933.
+					chanOChan <- wrapInPaginationPair(nil, nil)
 				}
 			}
 		}


### PR DESCRIPTION
Ensure that nil is properly sent back after remote
change/file resolution. This regression was caused
by forgetting to send back that nil.

This regression was caused by PR
https://github.com/odeke-em/drive/pull/741.

The consequence of the bug was that trying to push
from non-existent folders would erraneously give
back
```shell
Resolving...
Everything is up-to-date.
```

since the remotesChan channel would get closed
after resolution without sending notifying
whoever was resolving that the file or parent didn't
exist remotely.

Fixes #933