### PR TITLE
Fix minor english in the Google Service Account section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,7 @@ drive init --service-account-file <gsa_json_file_path> ~/gdrive
 cd ~/gdrive
 ```
 
-where <gsa_json_file_path> must the GSA credentials in JSON form.
-This feature was implemented as requested by:
-+ https://github.com/odeke-em/drive/issues/879
-
+Where <gsa_json_file_path> must a [Google Service Account credentials](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount) file in JSON form.
 
 ### De Initializing
 


### PR DESCRIPTION
1. correct ``where <gsa_json_file_path> must the GSA credentials in JSON form`` as it is missing a word
2. remove link to ticket (none of the other sections have it)