### PR TITLE
src: fix go test + vet feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 language: go
 go:
   - 1.7
+  - 1.8
+  - 1.9
   - tip
 install:
   - go get -t ./...
 script:
-  go test -v -cover ./src/...
+  go test -v -race -cover ./src/...

--- a/src/misc_test.go
+++ b/src/misc_test.go
@@ -65,7 +65,7 @@ func TestRemoteOpToChangerTranslator(t *testing.T) {
 		vptr2 := reflect.ValueOf(tc.wantedFn).Pointer()
 
 		if vptr1 != vptr2 {
-			t.Errorf("expected %q expected (%v) got (%v)", tc.name, tc.wantedFn, got)
+			t.Errorf("expected %q expected (%p) got (%p)", tc.name, tc.wantedFn, got)
 		}
 	}
 }
@@ -115,7 +115,7 @@ func TestLocalOpToChangerTranslator(t *testing.T) {
 		vptr2 := reflect.ValueOf(tc.wantedFn).Pointer()
 
 		if vptr1 != vptr2 {
-			t.Errorf("expected %q expected (%v) got (%v)", tc.name, tc.wantedFn, got)
+			t.Errorf("expected %q expected (%p) got (%p)", tc.name, tc.wantedFn, got)
 		}
 	}
 }


### PR DESCRIPTION
Fix go vet feedback but change format specifiers for
functions from "%v" to "%p".

Shout-outs to @jean-christophe-manciot for helping
point this out that tips were failing on tip, without
any code changes.