### PR TITLE
Fix case in option in trash prompt

### DIFF
--- a/src/trash.go
+++ b/src/trash.go
@@ -234,7 +234,7 @@ func (g *Commands) reduceForTrash(args []string, opt *trashOpt) error {
 	}
 
 	if opt.permanent && g.opts.canPrompt() {
-		status := promptForChanges("This operation is irreversible. Continue [Y/N] ")
+		status := promptForChanges("This operation is irreversible. Continue [Y/n] ")
 		if !accepted(status) {
 			return status.Error()
 		}


### PR DESCRIPTION
On `delete` option, the prompt shows `[Y/N]` when it should show `[Y/n]` as in \[2\] (or I believe so :sweat_smile:  )

\[1\]:
https://github.com/odeke-em/drive/blob/467def294e141ef4580b31749e95b2589d568dae/src/trash.go#L237
\[2\]:
https://github.com/odeke-em/drive/blob/313053b3dee5a2f553385e7e1b8a871e6193ceb0/src/misc.go#L324