### PR TITLE
Remove support for Go <1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.7
-  - 1.8
   - 1.9
   - tip
 install:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
 
 ### Requirements
 
-go 1.7.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
+go 1.9.X or higher is required. See [here](https://golang.org/doc/install) for installation instructions and platform installers.
 
 * Make sure to set your GOPATH in your env, .bashrc or .bash\_profile file. If you have not yet set it, you can do so like this:
 


### PR DESCRIPTION
Not sure what the plan is for supporting Golang <1.9, but it may just be easier to only support the last 3 versions (seems reasonable).

Libraries that this project depends on are not compatible with Golang
<1.9. Specifically, the build is failing on [golang/oauth2](https://github.com/golang/oauth2/blob/master/google/default.go#L38)
due to a type alias which is not supported in <1.9.

This commit:

- Removes support in Travis to fix builds failing on <1.9
- Update README.md to show support at >=1.9.x